### PR TITLE
Switch out the current semver parsing package.

### DIFF
--- a/controllers/policy_test.go
+++ b/controllers/policy_test.go
@@ -74,7 +74,7 @@ var _ = Describe("ImagePolicy controller", func() {
 				},
 				Policy: imagev1alpha1.ImagePolicyChoice{
 					SemVer: &imagev1alpha1.SemVerPolicy{
-						Range: "1.0.x",
+						Range: "<1.1.0-0",
 					},
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fluxcd/image-reflector-controller
 go 1.14
 
 require (
-	github.com/Masterminds/semver/v3 v3.1.0
+	github.com/blang/semver/v4 v4.0.0
 	github.com/fluxcd/pkg/recorder v0.0.5
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-containerregistry v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -127,7 +127,10 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
+github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=


### PR DESCRIPTION
This replaces the current use of Masterminds/semver for blang/semver.

This is perhaps a more compliant package, but it does change the way that
prerelease versions are determined.

Previously 1.0.x did not match 1.1.0-beta but now, to get the same behaviour, use <1.1.0-0.