### PR TITLE
Add support for suspending image scans.

### DIFF
--- a/api/v1alpha1/imagerepository_types.go
+++ b/api/v1alpha1/imagerepository_types.go
@@ -33,6 +33,11 @@ type ImageRepositorySpec struct {
 	// scans of the image repository.
 	// +optional
 	ScanInterval *metav1.Duration `json:"scanInterval,omitempty"`
+
+	// This flag tells the controller to suspend subsequent image scans.
+	// It does not apply to already started scans. Defaults to false.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 type ScanResult struct {

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -51,6 +51,11 @@ spec:
                 description: ScanInterval is the (minimum) length of time to wait
                   between scans of the image repository.
                 type: string
+              suspend:
+                description: This flag tells the controller to suspend
+                  scanning of the image repository.
+                  Defaults to false.
+                type: boolean
             type: object
           status:
             description: ImageRepositoryStatus defines the observed state of ImageRepository


### PR DESCRIPTION
This adds support for suspending the scanning of an ImageRepository.

Addresses the first part of #19