### PR TITLE
Use credentials from secret

### DIFF
--- a/api/v1alpha1/imagerepository_types.go
+++ b/api/v1alpha1/imagerepository_types.go
@@ -36,6 +36,12 @@ type ImageRepositorySpec struct {
 	// +optional
 	ScanInterval *metav1.Duration `json:"scanInterval,omitempty"`
 
+	// SecretRef can be given the name of a secret containing
+	// credentials to use for the image registry. The secret should be
+	// created with `kubectl create secret docker-registry`, or the
+	// equivalent.
+	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
+
 	// This flag tells the controller to suspend subsequent image scans.
 	// It does not apply to already started scans. Defaults to false.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -217,6 +218,11 @@ func (in *ImageRepositorySpec) DeepCopyInto(out *ImageRepositorySpec) {
 	if in.ScanInterval != nil {
 		in, out := &in.ScanInterval, &out.ScanInterval
 		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.SecretRef != nil {
+		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
 }

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -51,6 +51,16 @@ spec:
                 description: ScanInterval is the (minimum) length of time to wait
                   between scans of the image repository.
                 type: string
+              secretRef:
+                description: SecretRef can be given the name of a secret containing
+                  credentials to use for the image registry. The secret should be
+                  created with `kubectl create secret docker-registry`, or the equivalent.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
               suspend:
                 description: This flag tells the controller to suspend subsequent
                   image scans. It does not apply to already started scans. Defaults

--- a/controllers/policy_test.go
+++ b/controllers/policy_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"net/http/httptest"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -33,9 +34,20 @@ import (
 // has an example of loading a test registry with a random image.
 
 var _ = Describe("ImagePolicy controller", func() {
+
+	var registryServer *httptest.Server
+
+	BeforeEach(func() {
+		registryServer = newRegistryServer()
+	})
+
+	AfterEach(func() {
+		registryServer.Close()
+	})
+
 	It("calculates an image from a repository's tags", func() {
 		versions := []string{"0.1.0", "0.1.1", "0.2.0", "1.0.0", "1.0.1", "1.0.2", "1.1.0-alpha"}
-		imgRepo := loadImages("test-semver-policy", versions)
+		imgRepo := loadImages(registryServer, "test-semver-policy", versions)
 
 		repo := imagev1alpha1.ImageRepository{
 			Spec: imagev1alpha1.ImageRepositorySpec{

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Context("Registry handler", func() {
+
+	It("serves a tag list", func() {
+		srv := newRegistryServer()
+		defer srv.Close()
+
+		uploadedTags := []string{"tag1", "tag2"}
+		repoString := loadImages(srv, "testimage", uploadedTags)
+		repo, _ := name.NewRepository(repoString)
+
+		tags, err := remote.List(repo)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tags).To(Equal(uploadedTags))
+	})
+})
+
+// ---
+
+// set up a local registry for testing scanning
+func newRegistryServer() *httptest.Server {
+	regHandler := registry.New()
+	srv := httptest.NewServer(&tagListHandler{
+		registryHandler: regHandler,
+		imagetags:       map[string][]string{},
+	})
+	return srv
+}
+
+// loadImages uploads images to the local registry, and returns the
+// image repo name.
+func loadImages(srv *httptest.Server, imageName string, versions []string) string {
+	registry := strings.TrimPrefix(srv.URL, "http://")
+	imgRepo := registry + "/" + imageName
+	for _, tag := range versions {
+		imgRef, err := name.NewTag(imgRepo + ":" + tag)
+		Expect(err).ToNot(HaveOccurred())
+		img, err := random.Image(512, 1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(remote.Write(imgRef, img)).To(Succeed())
+	}
+	return imgRepo
+}
+
+// the go-containerregistry test registry implementation does not
+// serve /myimage/tags/list. Until it does, I'm adding this handler.
+// NB:
+// - assumes repo name is a single element
+// - assumes no overwriting tags
+
+type tagListHandler struct {
+	registryHandler http.Handler
+	imagetags       map[string][]string
+}
+
+type tagListResult struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+func (h *tagListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// a tag list request has a path like: /v2/<repo>/tags/list
+	if withoutTagsList := strings.TrimSuffix(r.URL.Path, "/tags/list"); r.Method == "GET" && withoutTagsList != r.URL.Path {
+		repo := strings.TrimPrefix(withoutTagsList, "/v2/")
+		if tags, ok := h.imagetags[repo]; ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			result := tagListResult{
+				Name: repo,
+				Tags: tags,
+			}
+			Expect(json.NewEncoder(w).Encode(result)).To(Succeed())
+			println("Requested tags", repo, strings.Join(tags, ", "))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	// record the fact of a PUT to a tag; the path looks like: /v2/<repo>/manifests/<tag>
+	h.registryHandler.ServeHTTP(w, r)
+	if r.Method == "PUT" {
+		pathElements := strings.Split(r.URL.Path, "/")
+		if len(pathElements) == 5 && pathElements[1] == "v2" && pathElements[3] == "manifests" {
+			repo, tag := pathElements[2], pathElements[4]
+			println("Recording tag", repo, tag)
+			h.imagetags[repo] = append(h.imagetags[repo], tag)
+		}
+	}
+}

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package controllers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -48,13 +50,36 @@ var _ = Context("Registry handler", func() {
 
 // ---
 
+// pre-populated db of tags, so it's not necessary to upload images to
+// get results from remote.List.
+var convenientTags = map[string][]string{
+	"convenient": []string{
+		"tag1", "tag2",
+	},
+}
+
 // set up a local registry for testing scanning
 func newRegistryServer() *httptest.Server {
 	regHandler := registry.New()
 	srv := httptest.NewServer(&tagListHandler{
 		registryHandler: regHandler,
-		imagetags:       map[string][]string{},
+		imagetags:       convenientTags,
 	})
+	return srv
+}
+
+func newAuthenticatedRegistryServer(username, pass string) *httptest.Server {
+	regHandler := registry.New()
+	regHandler = &tagListHandler{
+		registryHandler: regHandler,
+		imagetags:       convenientTags,
+	}
+	regHandler = &authHandler{
+		registryHandler: regHandler,
+		allowedUser:     username,
+		allowedPass:     pass,
+	}
+	srv := httptest.NewServer(regHandler)
 	return srv
 }
 
@@ -119,3 +144,83 @@ func (h *tagListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 }
+
+// there's no authentication in go-containerregistry/pkg/registry;
+// this wrapper adds basic auth to a registry handler. NB: the
+// important thing is to be able to test that the credentials get from
+// the secret to the registry API library; it's assumed that the
+// registry API library does e.g., OAuth2 correctly.  See
+// https://tools.ietf.org/html/rfc7617 regarding basic authentication.
+
+type authHandler struct {
+	allowedUser, allowedPass string
+	registryHandler          http.Handler
+}
+
+// ServeHTTP serves a request which needs authentication.
+func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		w.Header().Add("WWW-Authenticate", `Basic realm="Registry"`)
+		w.WriteHeader(401)
+		return
+	}
+	if !strings.HasPrefix(authHeader, "Basic ") {
+		w.WriteHeader(403)
+		w.Write([]byte(`Authorization header does not being with "Basic "`))
+		return
+	}
+	namePass, err := base64.StdEncoding.DecodeString(authHeader[6:])
+	if err != nil {
+		w.WriteHeader(403)
+		w.Write([]byte(`Authorization header doesn't appear to be base64-encoded`))
+		return
+	}
+	namePassSlice := strings.SplitN(string(namePass), ":", 2)
+	if len(namePassSlice) != 2 {
+		w.WriteHeader(403)
+		w.Write([]byte(`Authorization header doesn't appear to be colon-separated value `))
+		w.Write(namePass)
+		return
+	}
+	if namePassSlice[0] != h.allowedUser || namePassSlice[1] != h.allowedPass {
+		w.WriteHeader(403)
+		w.Write([]byte(`Authorization failed: wrong username or password`))
+		return
+	}
+	h.registryHandler.ServeHTTP(w, r)
+}
+
+var _ = Context("Authentication handler", func() {
+
+	var registryServer *httptest.Server
+	var username, password string
+
+	BeforeEach(func() {
+		username = "user"
+		password = "password1"
+		registryServer = newAuthenticatedRegistryServer(username, password)
+	})
+
+	AfterEach(func() {
+		registryServer.Close()
+	})
+
+	It("rejects requests without authentication", func() {
+		repo, err := name.NewRepository(strings.TrimPrefix(registryServer.URL, "http://") + "/convenient")
+		Expect(err).ToNot(HaveOccurred())
+		_, err = remote.List(repo)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("accepts requests with correct authentication", func() {
+		repo, err := name.NewRepository(strings.TrimPrefix(registryServer.URL, "http://") + "/convenient")
+		Expect(err).ToNot(HaveOccurred())
+		auth := &authn.Basic{
+			Username: username,
+			Password: password,
+		}
+		_, err = remote.List(repo, remote.WithAuth(auth))
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/controllers/secret_test.go
+++ b/controllers/secret_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestExtractAuthn(t *testing.T) {
+	// the secret in testdata/secret.json was created with kubectl
+	// create secret docker-registry. Test that it can be decoded to
+	// get an authentication value.
+	b, err := ioutil.ReadFile("testdata/secret.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var secret corev1.Secret
+	if err = json.Unmarshal(b, &secret); err != nil {
+		t.Fatal(err)
+	}
+	auth, err := authFromSecret(secret, "https://index.docker.io/v1/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	authConfig, err := auth.Authorization()
+	if err != nil {
+		t.Fatal()
+	}
+	if authConfig.Username != "fooser" || authConfig.Password != "foopass" {
+		t.Errorf("expected username/password to be fooser/foopass, got %s/%s",
+			authConfig.Username, authConfig.Password)
+	}
+}

--- a/controllers/testdata/secret.json
+++ b/controllers/testdata/secret.json
@@ -1,0 +1,32 @@
+{
+    "apiVersion": "v1",
+    "data": {
+        ".dockerconfigjson": "eyJhdXRocyI6eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsidXNlcm5hbWUiOiJmb29zZXIiLCJwYXNzd29yZCI6ImZvb3Bhc3MiLCJlbWFpbCI6ImZvb0BleGFtcGxlLmNvbSIsImF1dGgiOiJabTl2YzJWeU9tWnZiM0JoYzNNPSJ9fX0="
+    },
+    "kind": "Secret",
+    "metadata": {
+        "creationTimestamp": "2020-10-21T13:50:57Z",
+        "managedFields": [
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:data": {
+                        ".": {},
+                        "f:.dockerconfigjson": {}
+                    },
+                    "f:type": {}
+                },
+                "manager": "kubectl",
+                "operation": "Update",
+                "time": "2020-10-21T13:50:57Z"
+            }
+        ],
+        "name": "docker-secret",
+        "namespace": "default",
+        "resourceVersion": "454577",
+        "selfLink": "/api/v1/namespaces/default/secrets/docker-secret",
+        "uid": "93943236-bd36-439b-b267-15d4c4a4ef05"
+    },
+    "type": "kubernetes.io/dockerconfigjson"
+}


### PR DESCRIPTION
This lets you create a secret with registry credentials, then refer to it in the `ImageRepository` field `secretRef` so it can be used to scan image repositories that require authentication.
