### PR TITLE
Remove `find -execdir` from `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ all: manager
 
 # Run tests
 test: generate fmt vet manifests
-	find . -maxdepth 2 -type f -name 'go.mod' -execdir go test ./... -coverprofile cover.out \;
+	go test ./... -coverprofile cover.out
+	cd api; go test ./... -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet
@@ -50,11 +51,13 @@ manifests: controller-gen
 
 # Run go fmt against code
 fmt:
-	find . -maxdepth 2 -type f -name 'go.mod' -execdir go fmt ./... \;
+	go fmt ./...
+	cd api; go fmt ./...
 
 # Run go vet against code
 vet:
-	find . -maxdepth 2 -type f -name 'go.mod' -execdir go vet ./... \;
+	go vet ./...
+	cd api; go vet ./...
 
 # Generate code
 generate: controller-gen


### PR DESCRIPTION
As it does not make error codes surface.
