### PR TITLE
Use kubebuilder action from main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: 1.14.x
     - name: Set up kubebuilder
-      uses: fluxcd/pkg/actions/kubebuilder@v0.0.4
+      uses: fluxcd/pkg/actions/kubebuilder@main
     - name: Run tests
       run: make test
       env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Set up Go
-      uses: actions/setup-go@v2-beta
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.14.x
+        go-version: 1.15.x
     - name: Set up kubebuilder
       uses: fluxcd/pkg/actions/kubebuilder@main
     - name: Run tests


### PR DESCRIPTION
This avoids a hard deprecation in GitHub Actions, of add_path.
