### PR TITLE
Note shared maintainers from fluxcd/flux2

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,7 +2,11 @@ The maintainers are generally available in Slack at
 https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages/CLAJ40HV3)
 (obtain an invitation at https://slack.cncf.io/).
 
+In additional to those listed below, this project shares maintainers
+from the main Flux v2 git repository, as listed in
+
+    https://github.com/fluxcd/flux2/blob/main/MAINTAINERS
+
 In alphabetical order:
 
 Michael Bridgen, Weaveworks <michael@weave.works> (github: @squaremo, slack: Michael Bridgen)
-Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)


### PR DESCRIPTION
The GitOps toolkit controllers usually adopt the maintainers of the
"central" Flux v2 git repo, fluxcd/flux2. For convenience of keeping
track, it is easier to refer to the MAINTAINER files there.

NB this expands the maintainers of this repo, but only to those who
were effectively considered maintainers anyway (i.e., it reflects the
established practice.)

See https://github.com/fluxcd/flux2/discussions/515 for the proposal.