### PR TITLE
Add BadgerDB as a persistent store for the tag data.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN go mod download
 # copy source code
 COPY main.go main.go
 COPY controllers/ controllers/
+COPY internal/ internal/
 
 # build without giving the arch, so that it gets it from the machine
 RUN CGO_ENABLED=0 go build -a -o image-reflector-controller main.go

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -59,6 +59,10 @@ spec:
         volumeMounts:
           - name: temp
             mountPath: /tmp
+          - name: data
+            mountPath: /data
       volumes:
         - name: temp
+          emptyDir: {}
+        - name: data
           emptyDir: {}

--- a/controllers/database.go
+++ b/controllers/database.go
@@ -16,30 +16,16 @@ limitations under the License.
 
 package controllers
 
-import (
-	"sync"
-)
-
-type database struct {
-	mu       sync.RWMutex
-	repoTags map[string][]string
+// DatabaseWriter implementations record the tags for an image repository.
+type DatabaseWriter interface {
+	SetTags(repo string, tags []string) error
 }
 
-func NewDatabase() *database {
-	return &database{
-		repoTags: map[string][]string{},
-	}
-}
-
-func (db *database) Tags(repo string) []string {
-	db.mu.RLock()
-	tags := db.repoTags[repo]
-	db.mu.RUnlock()
-	return tags
-}
-
-func (db *database) SetTags(repo string, tags []string) {
-	db.mu.Lock()
-	db.repoTags[repo] = tags
-	db.mu.Unlock()
+// DatabaseReader implementations get the stored set of tags for an image
+// repository.
+//
+// If no tags are availble for the repo, then implementations should return an
+// empty set of tags.
+type DatabaseReader interface {
+	Tags(repo string) ([]string, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace github.com/fluxcd/image-reflector-controller/api => ./api
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.0
+	github.com/dgraph-io/badger v1.6.2
 	github.com/fluxcd/image-reflector-controller/api v0.0.0-00010101000000-000000000000
 	github.com/fluxcd/pkg/apis/meta v0.4.0
 	github.com/fluxcd/pkg/runtime v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ contrib.go.opencensus.io/exporter/stackdriver v0.12.1/go.mod h1:iwB6wGarfphGGe/e
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIoKjsnZuH8vjyaysT/ses3EvZeaV/1UkF2M=
+github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=
@@ -87,6 +89,7 @@ github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvo
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -138,6 +141,7 @@ github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMS
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -167,7 +171,13 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
+github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
+github.com/dgraph-io/badger v1.6.2/go.mod h1:JW2yswe3V058sS0kZ2h/AXeDSqFjxnZcRrVH//y2UQE=
+github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
+github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
@@ -185,6 +195,7 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
@@ -662,6 +673,8 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
 github.com/sourcegraph/go-diff v0.5.3/go.mod h1:v9JDtjCE4HHHCZGId75rg8gkKKa98RVjBcBGsVmMmak=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/internal/database/badger.go
+++ b/internal/database/badger.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Flux CD authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/dgraph-io/badger"
+)
+
+const tagsPrefix = "tags"
+
+// BadgerDatabase provides implementations of the tags database based on Badger.
+type BadgerDatabase struct {
+	db *badger.DB
+}
+
+// NewBadgerDatabase creates and returns a new database implementation using
+// Badger for storing the image tags.
+func NewBadgerDatabase(db *badger.DB) *BadgerDatabase {
+	return &BadgerDatabase{
+		db: db,
+	}
+}
+
+// Tags implements the DatabaseReader interface, fetching the tags for the repo.
+//
+// If the repo does not exist, an empty set of tags is returned.
+func (a *BadgerDatabase) Tags(repo string) ([]string, error) {
+	var tags []string
+	err := a.db.View(func(txn *badger.Txn) error {
+		var err error
+		tags, err = getOrEmpty(txn, repo)
+		return err
+	})
+	return tags, err
+}
+
+// SetTags implements the DatabaseWriter interface, recording the tags against
+// the repo.
+//
+// It overwrites existing tag sets for the provided repo.
+func (a *BadgerDatabase) SetTags(repo string, tags []string) error {
+	b, err := marshal(tags)
+	if err != nil {
+		return err
+	}
+	return a.db.Update(func(txn *badger.Txn) error {
+		e := badger.NewEntry(keyForRepo(tagsPrefix, repo), b)
+		return txn.SetEntry(e)
+	})
+}
+
+func keyForRepo(prefix, repo string) []byte {
+	return []byte(fmt.Sprintf("%s:%s", prefix, repo))
+}
+
+func getOrEmpty(txn *badger.Txn, repo string) ([]string, error) {
+	item, err := txn.Get(keyForRepo(tagsPrefix, repo))
+	if err == badger.ErrKeyNotFound {
+		return []string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var tags []string
+	err = item.Value(func(val []byte) error {
+		tags, err = unmarshal(val)
+		return err
+	})
+	return tags, err
+}
+
+func marshal(t []string) ([]byte, error) {
+	return json.Marshal(t)
+}
+
+func unmarshal(b []byte) ([]string, error) {
+	var tags []string
+	if err := json.Unmarshal(b, &tags); err != nil {
+		return nil, err
+	}
+	return tags, nil
+}

--- a/internal/database/badger.go
+++ b/internal/database/badger.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Flux CD authors.
+Copyright 2020 The Flux authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/database/badger_test.go
+++ b/internal/database/badger_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package database
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/dgraph-io/badger"
+)
+
+const testRepo = "testing/testing"
+
+func TestGetWithUnknownRepo(t *testing.T) {
+	db := createBadgerDatabase(t)
+
+	tags, err := db.Tags(testRepo)
+	fatalIfError(t, err)
+
+	if !reflect.DeepEqual([]string{}, tags) {
+		t.Fatalf("Tags() for unknown repo got %#v, want %#v", tags, []string{})
+	}
+}
+
+func TestSetTags(t *testing.T) {
+	db := createBadgerDatabase(t)
+	tags := []string{"latest", "v0.0.1", "v0.0.2"}
+
+	fatalIfError(t, db.SetTags(testRepo, tags))
+
+	loaded, err := db.Tags(testRepo)
+	fatalIfError(t, err)
+	if !reflect.DeepEqual(tags, loaded) {
+		t.Fatalf("SetTags failed, got %#v want %#v", loaded, tags)
+	}
+}
+
+func TestSetTagsOverwrites(t *testing.T) {
+	db := createBadgerDatabase(t)
+	tags1 := []string{"latest", "v0.0.1", "v0.0.2"}
+	tags2 := []string{"latest", "v0.0.1", "v0.0.2", "v0.0.3"}
+	fatalIfError(t, db.SetTags(testRepo, tags1))
+
+	fatalIfError(t, db.SetTags(testRepo, tags2))
+
+	loaded, err := db.Tags(testRepo)
+	fatalIfError(t, err)
+	if !reflect.DeepEqual(tags2, loaded) {
+		t.Fatalf("failed to overwrite with SetTags: got %#v, want %#v", loaded, tags2)
+	}
+}
+
+func TestGetOnlyFetchesForRepo(t *testing.T) {
+	db := createBadgerDatabase(t)
+	tags1 := []string{"latest", "v0.0.1", "v0.0.2"}
+	fatalIfError(t, db.SetTags(testRepo, tags1))
+	testRepo2 := "another/repo"
+	tags2 := []string{"v0.0.3", "v0.0.4"}
+	fatalIfError(t, db.SetTags(testRepo2, tags2))
+
+	loaded, err := db.Tags(testRepo)
+	fatalIfError(t, err)
+	if !reflect.DeepEqual(tags1, loaded) {
+		t.Fatalf("Tags() failed got %#v, want %#v", loaded, tags2)
+	}
+}
+
+func createBadgerDatabase(t *testing.T) *BadgerDatabase {
+	t.Helper()
+	dir, err := ioutil.TempDir(os.TempDir(), "badger")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := badger.Open(badger.DefaultOptions(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.RemoveAll(dir)
+	})
+	return NewBadgerDatabase(db)
+}
+
+func fatalIfError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This introduces a key/value store for tags, with the keys being the
images and the values being JSON encoded versions of the tags.

The Badger data is stored in a PVC.

Related to #12