### PR TITLE
Update fluxcd/pkg/runtime to v0.8.0

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -3,7 +3,7 @@ module github.com/fluxcd/image-reflector-controller/api
 go 1.15
 
 require (
-	github.com/fluxcd/pkg/apis/meta v0.6.0
+	github.com/fluxcd/pkg/apis/meta v0.7.0
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -88,8 +88,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fluxcd/pkg/apis/meta v0.6.0 h1:3ETc/Yz4qXGKLj+Iti6vKFwVE024WX+Jr+jIHlxj7zs=
-github.com/fluxcd/pkg/apis/meta v0.6.0/go.mod h1:yHuY8kyGHYz22I0jQzqMMGCcHViuzC/WPdo9Gisk8Po=
+github.com/fluxcd/pkg/apis/meta v0.7.0 h1:5e8gm4OLqjuKWdrOIY5DEEsjcwzyJFK8rCDesJ+V8IY=
+github.com/fluxcd/pkg/apis/meta v0.7.0/go.mod h1:yHuY8kyGHYz22I0jQzqMMGCcHViuzC/WPdo9Gisk8Po=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=

--- a/api/v1alpha1/imagepolicy_types.go
+++ b/api/v1alpha1/imagepolicy_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fluxcd/pkg/apis/meta"
@@ -31,7 +30,7 @@ type ImagePolicySpec struct {
 	// ImageRepositoryRef points at the object specifying the image
 	// being scanned
 	// +required
-	ImageRepositoryRef corev1.LocalObjectReference `json:"imageRepositoryRef"`
+	ImageRepositoryRef meta.LocalObjectReference `json:"imageRepositoryRef"`
 	// Policy gives the particulars of the policy to be followed in
 	// selecting the most recent image
 	// +required

--- a/api/v1alpha1/imagerepository_types.go
+++ b/api/v1alpha1/imagerepository_types.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fluxcd/pkg/apis/meta"
@@ -47,7 +46,7 @@ type ImageRepositorySpec struct {
 	// credentials to use for the image registry. The secret should be
 	// created with `kubectl create secret docker-registry`, or the
 	// equivalent.
-	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
+	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`
 
 	// This flag tells the controller to suspend subsequent image scans.
 	// It does not apply to already started scans. Defaults to false.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"github.com/fluxcd/pkg/apis/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -239,7 +239,7 @@ func (in *ImageRepositorySpec) DeepCopyInto(out *ImageRepositorySpec) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(corev1.LocalObjectReference)
+		*out = new(meta.LocalObjectReference)
 		**out = **in
 	}
 }

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
@@ -61,9 +61,10 @@ spec:
                   image being scanned
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name of the referent
                     type: string
+                required:
+                - name
                 type: object
               policy:
                 description: Policy gives the particulars of the policy to be followed

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -57,9 +57,10 @@ spec:
                   created with `kubectl create secret docker-registry`, or the equivalent.
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name of the referent
                     type: string
+                required:
+                - name
                 type: object
               suspend:
                 description: This flag tells the controller to suspend subsequent

--- a/controllers/policy_test.go
+++ b/controllers/policy_test.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"net/http/httptest"
 
+	"github.com/fluxcd/pkg/apis/meta"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -83,7 +83,7 @@ var _ = Describe("ImagePolicy controller", func() {
 				}
 				pol := imagev1alpha1.ImagePolicy{
 					Spec: imagev1alpha1.ImagePolicySpec{
-						ImageRepositoryRef: corev1.LocalObjectReference{
+						ImageRepositoryRef: meta.LocalObjectReference{
 							Name: imageObjectName.Name,
 						},
 						Policy: imagev1alpha1.ImagePolicyChoice{
@@ -148,7 +148,7 @@ var _ = Describe("ImagePolicy controller", func() {
 				}
 				pol := imagev1alpha1.ImagePolicy{
 					Spec: imagev1alpha1.ImagePolicySpec{
-						ImageRepositoryRef: corev1.LocalObjectReference{
+						ImageRepositoryRef: meta.LocalObjectReference{
 							Name: imageObjectName.Name,
 						},
 						Policy: imagev1alpha1.ImagePolicyChoice{

--- a/controllers/scan_test.go
+++ b/controllers/scan_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 
+	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo"
@@ -30,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	imagev1alpha1 "github.com/fluxcd/image-reflector-controller/api/v1alpha1"
-	"github.com/fluxcd/pkg/apis/meta"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -249,7 +249,7 @@ var _ = Describe("ImageRepository controller", func() {
 				Spec: imagev1alpha1.ImageRepositorySpec{
 					Interval: metav1.Duration{Duration: reconciliationInterval},
 					Image:    imgRepo,
-					SecretRef: &corev1.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "docker",
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	// fix for ARM builds
 	github.com/dgraph-io/badger/v3 v3.0.0-20210118150219-63f09c34dec1
 	github.com/fluxcd/image-reflector-controller/api v0.3.0
-	github.com/fluxcd/pkg/apis/meta v0.6.0
-	github.com/fluxcd/pkg/runtime v0.7.0
+	github.com/fluxcd/pkg/apis/meta v0.7.0
+	github.com/fluxcd/pkg/runtime v0.8.0
 	github.com/fluxcd/pkg/version v0.0.1
 	github.com/go-logr/logr v0.3.0
 	github.com/google/go-containerregistry v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -221,10 +221,10 @@ github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQo
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fluxcd/pkg/apis/meta v0.6.0 h1:3ETc/Yz4qXGKLj+Iti6vKFwVE024WX+Jr+jIHlxj7zs=
-github.com/fluxcd/pkg/apis/meta v0.6.0/go.mod h1:yHuY8kyGHYz22I0jQzqMMGCcHViuzC/WPdo9Gisk8Po=
-github.com/fluxcd/pkg/runtime v0.7.0 h1:AMzqHGae0zqDQAmKwa1htjStk2wphwWF0xQw/zD3FY4=
-github.com/fluxcd/pkg/runtime v0.7.0/go.mod h1:1dzGFwtowST5AIW5i9f0Pn0fMhCmOHFyBizuPJSKX+s=
+github.com/fluxcd/pkg/apis/meta v0.7.0 h1:5e8gm4OLqjuKWdrOIY5DEEsjcwzyJFK8rCDesJ+V8IY=
+github.com/fluxcd/pkg/apis/meta v0.7.0/go.mod h1:yHuY8kyGHYz22I0jQzqMMGCcHViuzC/WPdo9Gisk8Po=
+github.com/fluxcd/pkg/runtime v0.8.0 h1:cnSBZJLcXlKgjXpFFFExu+4ZncIxmPgNIx+ErLcCLnA=
+github.com/fluxcd/pkg/runtime v0.8.0/go.mod h1:tQwEN+RESjJmtwSSv7I+6bkNM9raIXpGsCjruaIVX6A=
 github.com/fluxcd/pkg/version v0.0.1 h1:/8asQoDXSThz3csiwi4Qo8Zb6blAxLXbtxNgeMJ9bCg=
 github.com/fluxcd/pkg/version v0.0.1/go.mod h1:WAF4FEEA9xyhngF8TDxg3UPu5fA1qhEYV8Pmi2Il01Q=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=


### PR DESCRIPTION
Changes:
- update fluxcd/pkg/apis/meta to v0.7.0
- update fluxcd/pkg/runtime to v0.8.0
- hook Kubernetes client and logger flags from runtime
- use LocalObjectReference from fluxcd/pkg/apis/meta in the API

Note that this PR adds two new flags:
```
--kube-api-burst int            The maximum burst queries-per-second of requests sent to the Kubernetes API. (default 50)
--kube-api-qps float32          The maximum queries-per-second of requests sent to the Kubernetes API. (default 20)
```