### PR TITLE
Update BadgerDB to v3.2011.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,7 @@ replace github.com/fluxcd/image-reflector-controller/api => ./api
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	// fix for ARM builds
-	github.com/dgraph-io/badger/v3 v3.0.0-20210118150219-63f09c34dec1
+	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/fluxcd/image-reflector-controller/api v0.4.1
 	github.com/fluxcd/pkg/apis/meta v0.7.0
 	github.com/fluxcd/pkg/runtime v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -182,10 +182,10 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
-github.com/dgraph-io/badger/v3 v3.0.0-20210118150219-63f09c34dec1 h1:5r/7OjpEnF2CdQCT4LLxgn4WMWND+NEDe0MBGrmLgWY=
-github.com/dgraph-io/badger/v3 v3.0.0-20210118150219-63f09c34dec1/go.mod h1:6ao9JG07ANaxT3Fb6x3+mBAfaQkWPnFoH+OtSxewGIk=
-github.com/dgraph-io/ristretto v0.0.4-0.20201224172411-e860a6c48e8a h1:jbJJPy2En2HoeNzt3C8Pc03O6+WRmle0O+xTNiORZW0=
-github.com/dgraph-io/ristretto v0.0.4-0.20201224172411-e860a6c48e8a/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
+github.com/dgraph-io/badger/v3 v3.2011.1 h1:Hmyof0WMEF/QtutX5SQHzIMnJQxb/IrSzhjckV2SD6g=
+github.com/dgraph-io/badger/v3 v3.2011.1/go.mod h1:0rLLrQpKVQAL0or/lBLMQznhr6dWWX7h5AKnmnqx268=
+github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d h1:eQYOG6A4td1tht0NdJB9Ls6DsXRGb2Ft6X9REU/MbbE=
+github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=


### PR DESCRIPTION
Includes fixes for ARM 32bit build that we've been using from master
