### PR TITLE
Update ImagePolicy example

### DIFF
--- a/docs/spec/v1alpha1/imagepolicies.md
+++ b/docs/spec/v1alpha1/imagepolicies.md
@@ -126,18 +126,23 @@ be marked as true when the policy rule has selected an image.
 
 ## Examples
 
-Select the latest `dev` branch build tagged as `<BRANCH>-<BUILD-ID>` (alphabetical):
+Select the latest `main` branch build tagged as `${GIT_BRANCH}-${GIT_SHA:0:7}-$(date +%s)` (alphabetical):
 
 ```yaml
 kind: ImagePolicy
 spec:
   filterTags:
-    pattern: '^dev-(?P<id>.*)'
-    extract: '$id'
+    pattern: '^main-[a-fA-F0-9]+-(?P<ts>.*)'
+    extract: '$ts'
   policy:
     alphabetical:
       order: asc
 ```
+
+A more strict filter would be `^main-[a-fA-F0-9]+-(?P<ts>[1-9][0-9]*)`.
+Before applying policies in-cluster, you can validate your filters using
+a [Go regular expression tester](https://regoio.herokuapp.com)
+or [regex101.com](https://regex101.com/).
 
 Select the latest stable version (semver):
 


### PR DESCRIPTION
In Flux1 we told users to tag their images with `${GIT_BRANCH}-${GIT_SHA:0:7}`, migrating to Flux2 they'll have to change the format to `${GIT_BRANCH}-${GIT_SHA:0:7}-$(date +%s)`.

This PR updates the `ImagePolicy` example to help users craft a policy that filters tags based on branch name and selects the latest build:

```yaml
kind: ImagePolicy
spec:
  filterTags:
    pattern: '^main-[a-fA-F0-9]+-(?P<ts>.*)'
    extract: '$ts'
  policy:
    alphabetical:
      order: asc
``` 

Ref: https://github.com/fluxcd/flux2/discussions/802