### PR TITLE
Update Alpine to v3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY internal/ internal/
 # build without giving the arch, so that it gets it from the machine
 RUN CGO_ENABLED=0 go build -a -o image-reflector-controller main.go
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/image-reflector-controller"
 
@@ -34,7 +34,7 @@ RUN apk add --no-cache ca-certificates tini
 
 COPY --from=builder /workspace/image-reflector-controller /usr/local/bin/
 
-RUN addgroup -S controller && adduser -S -g controller controller
+RUN addgroup -S controller && adduser -S controller -G controller
 
 USER controller
 

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         prometheus.io/port: "8080"
     spec:
       terminationGracePeriodSeconds: 10
+      # Required for AWS IAM Role bindings
+      # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
+      securityContext:
+        fsGroup: 1337
       containers:
       - name: manager
         image: fluxcd/image-reflector-controller


### PR DESCRIPTION
Changes:
- set fsGroup to allow AWS IAM Role bindings 
- fix the group assignment in Alpine
- bump Alpine to 3.13
