### PR TITLE
Remove v1alpha1 API from Scheme

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	imagev1_reflect "github.com/fluxcd/image-reflector-controller/api/v1alpha1"
 	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
 	"github.com/fluxcd/image-reflector-controller/internal/database"
 	// +kubebuilder:scaffold:imports
@@ -85,9 +84,6 @@ var _ = BeforeSuite(func(done Done) {
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
-
-	err = imagev1_reflect.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
 
 	err = imagev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/fluxcd/pkg/runtime/pprof"
 	"github.com/fluxcd/pkg/runtime/probes"
 
-	imagev1_reflect "github.com/fluxcd/image-reflector-controller/api/v1alpha1"
 	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
 	"github.com/fluxcd/image-reflector-controller/controllers"
 	"github.com/fluxcd/image-reflector-controller/internal/database"
@@ -54,7 +53,6 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(imagev1_reflect.AddToScheme(scheme))
 	utilruntime.Must(imagev1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
This was accidentally done while mirroring the work done on the
image-automation-controller. It technically should not hurt, but
should not be either.

Follow up on #132 