### PR TITLE
Better error reporting for image policy evaluation

### DIFF
--- a/controllers/imagepolicy_controller.go
+++ b/controllers/imagepolicy_controller.go
@@ -158,7 +158,7 @@ func (r *ImagePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if latest == "" {
-		msg := "no image found for policy"
+		msg := fmt.Sprintf("Cannot determine latest tag for policy: %s", err.Error())
 		pol.Status.LatestImage = ""
 		imagev1.SetImagePolicyReadiness(
 			&pol,

--- a/internal/policy/numerical.go
+++ b/internal/policy/numerical.go
@@ -66,7 +66,7 @@ func (p *Numerical) Latest(versions []string) (string, error) {
 
 		switch {
 		case i == 0:
-			break // First iteration, nothing to compare
+			// First iteration, nothing to compare
 		case p.Order == NumericalOrderAsc && cv < pv, p.Order == NumericalOrderDesc && cv > pv:
 			continue
 		}

--- a/internal/policy/numerical_test.go
+++ b/internal/policy/numerical_test.go
@@ -113,6 +113,11 @@ func TestNumerical_Latest(t *testing.T) {
 			expectedVersion: "1",
 		},
 		{
+			label:     "With invalid numerical value",
+			versions:  []string{"0", "1a", "b"},
+			expectErr: true,
+		},
+		{
 			label:     "Empty version list",
 			versions:  []string{},
 			expectErr: true,


### PR DESCRIPTION
A more verbose message associated with the error should give the user
better understanding of the cause and the nature of the failure.