### PR TITLE
Make concurrent reconciliation configurable

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -66,15 +66,18 @@ const (
 // ImageRepositoryReconciler reconciles a ImageRepository object
 type ImageRepositoryReconciler struct {
 	client.Client
-	Scheme                  *runtime.Scheme
-	EventRecorder           kuberecorder.EventRecorder
-	ExternalEventRecorder   *events.Recorder
-	MetricsRecorder         *metrics.Recorder
-	MaxConcurrentReconciles int
-	Database                interface {
+	Scheme                *runtime.Scheme
+	EventRecorder         kuberecorder.EventRecorder
+	ExternalEventRecorder *events.Recorder
+	MetricsRecorder       *metrics.Recorder
+	Database              interface {
 		DatabaseWriter
 		DatabaseReader
 	}
+}
+
+type ImageRepositoryReconcilerOptions struct {
+	MaxConcurrentReconciles int
 }
 
 type dockerConfig struct {
@@ -354,12 +357,12 @@ func (r *ImageRepositoryReconciler) shouldScan(repo imagev1.ImageRepository, now
 	return false, when, nil
 }
 
-func (r *ImageRepositoryReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ImageRepositoryReconciler) SetupWithManager(mgr ctrl.Manager, opts ImageRepositoryReconcilerOptions) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&imagev1.ImageRepository{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicates.ReconcileRequestedPredicate{})).
 		WithOptions(controller.Options{
-			MaxConcurrentReconciles: r.MaxConcurrentReconciles,
+			MaxConcurrentReconciles: opts.MaxConcurrentReconciles,
 		}).
 		Complete(r)
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -105,14 +105,14 @@ var _ = BeforeSuite(func(done Done) {
 		Scheme:   scheme.Scheme,
 		Database: database.NewBadgerDatabase(badgerDB),
 	}
-	Expect(imageRepoReconciler.SetupWithManager(k8sMgr)).To(Succeed())
+	Expect(imageRepoReconciler.SetupWithManager(k8sMgr, ImageRepositoryReconcilerOptions{})).To(Succeed())
 
 	imagePolicyReconciler = &ImagePolicyReconciler{
 		Client:   k8sMgr.GetClient(),
 		Scheme:   scheme.Scheme,
 		Database: database.NewBadgerDatabase(badgerDB),
 	}
-	Expect(imagePolicyReconciler.SetupWithManager(k8sMgr)).To(Succeed())
+	Expect(imagePolicyReconciler.SetupWithManager(k8sMgr, ImagePolicyReconcilerOptions{})).To(Succeed())
 
 	// this must be started for the caches to be running, and thereby
 	// for the client to be usable.

--- a/main.go
+++ b/main.go
@@ -138,14 +138,15 @@ func main() {
 	pprof.SetupHandlers(mgr, setupLog)
 
 	if err = (&controllers.ImageRepositoryReconciler{
-		Client:                  mgr.GetClient(),
-		Scheme:                  mgr.GetScheme(),
-		EventRecorder:           mgr.GetEventRecorderFor(controllerName),
-		ExternalEventRecorder:   eventRecorder,
-		MetricsRecorder:         metricsRecorder,
-		Database:                db,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		EventRecorder:         mgr.GetEventRecorderFor(controllerName),
+		ExternalEventRecorder: eventRecorder,
+		MetricsRecorder:       metricsRecorder,
+		Database:              db,
+	}).SetupWithManager(mgr, controllers.ImageRepositoryReconcilerOptions{
 		MaxConcurrentReconciles: concurrent,
-	}).SetupWithManager(mgr); err != nil {
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", imagev1.ImageRepositoryKind)
 		os.Exit(1)
 	}
@@ -156,8 +157,9 @@ func main() {
 		ExternalEventRecorder: eventRecorder,
 		MetricsRecorder:       metricsRecorder,
 		Database:              db,
+	}).SetupWithManager(mgr, controllers.ImagePolicyReconcilerOptions{
 		MaxConcurrentReconciles: concurrent,
-	}).SetupWithManager(mgr); err != nil {
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", imagev1.ImagePolicyKind)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 		watchAllNamespaces      bool
 		storagePath             string
 		storageValueLogFileSize int64
+		concurrent              int
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -77,6 +78,7 @@ func main() {
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
 	flag.StringVar(&storagePath, "storage-path", "/data", "Where to store the persistent database of image metadata")
 	flag.Int64Var(&storageValueLogFileSize, "storage-value-log-file-size", 1<<28, "Set the database's memory mapped value log file size in bytes. Effective memory usage is about two times this size.")
+	flag.IntVar(&concurrent, "concurrent", 4, "The number of concurrent resource reconciles.")
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
 	leaderElectionOptions.BindFlags(flag.CommandLine)
@@ -136,12 +138,13 @@ func main() {
 	pprof.SetupHandlers(mgr, setupLog)
 
 	if err = (&controllers.ImageRepositoryReconciler{
-		Client:                mgr.GetClient(),
-		Scheme:                mgr.GetScheme(),
-		EventRecorder:         mgr.GetEventRecorderFor(controllerName),
-		ExternalEventRecorder: eventRecorder,
-		MetricsRecorder:       metricsRecorder,
-		Database:              db,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		EventRecorder:           mgr.GetEventRecorderFor(controllerName),
+		ExternalEventRecorder:   eventRecorder,
+		MetricsRecorder:         metricsRecorder,
+		Database:                db,
+		MaxConcurrentReconciles: concurrent,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", imagev1.ImageRepositoryKind)
 		os.Exit(1)
@@ -153,6 +156,7 @@ func main() {
 		ExternalEventRecorder: eventRecorder,
 		MetricsRecorder:       metricsRecorder,
 		Database:              db,
+		MaxConcurrentReconciles: concurrent,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", imagev1.ImagePolicyKind)
 		os.Exit(1)


### PR DESCRIPTION
Default for both, the ImageRepository and the ImagePolicy controllers
is 4 workers.

fix: #148

Signed-off-by: Max Jonas Werner <mail@makk.es>