### PR TITLE
Update installation CLI with kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ guide](https://toolkit.fluxcd.io/guides/image-update/).
 If you just want to run this controller for development purposes, do
 
 ```bash
-kustomize build github.com/fluxcd/image-reflector-controller//config/default/?ref=main | kubectl apply -f-
+kubectl kustomize https://github.com/fluxcd/image-reflector-controller.git//config/default/?ref=main | kubectl apply -f-
 ```
 
 [auto]: https://github.com/fluxcd/image-automation-controller


### PR DESCRIPTION
Context:

There is no need to install kustomize cli, it's already embedded in kubectl