### PR TITLE
Add setup-envtest to makefile & gh build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,13 +23,9 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16.x
-    - name: Set up kubebuilder
-      uses: fluxcd/pkg/actions/kubebuilder@main
+    - name: Setup envtest
+      uses: fluxcd/pkg/actions/envtest@main
     - name: Run tests
       run: make test
-      env:
-        KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
     - name: Build container image
       run: make docker-build IMG=ghcr.io/fluxcd/${{ github.event.repository.name }}:latest
-      env:
-        KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ IMG ?= fluxcd/image-reflector-controller
 # Produce CRDs that work back to Kubernetes 1.16
 CRD_OPTIONS ?= crd:crdVersions=v1
 
+ENVTEST_BIN_VERSION?=1.22.0
+KUBEBUILDER_ASSETS?=$(shell $(SETUP_ENVTEST) use -i $(ENVTEST_BIN_VERSION) -p path)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -13,8 +16,8 @@ endif
 all: manager
 
 # Run tests
-test: generate fmt vet manifests api-docs
-	go test ./... -coverprofile cover.out
+test: generate fmt vet manifests api-docs setup-envtest
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./... -coverprofile cover.out
 	cd api; go test ./... -coverprofile cover.out
 
 # Build manager binary
@@ -115,4 +118,20 @@ ifeq (, $(shell which gen-crd-api-reference-docs))
 API_REF_GEN=$(GOBIN)/gen-crd-api-reference-docs
 else
 API_REF_GEN=$(shell which gen-crd-api-reference-docs)
+endif
+
+# Find or download setup-envtest
+setup-envtest:
+ifeq (, $(shell which setup-envtest))
+        @{ \
+        set -e ;\
+        SETUP_ENVTEST_TMP_DIR=$$(mktemp -d) ;\
+        cd $$SETUP_ENVTEST_TMP_DIR ;\
+        go mod init tmp ;\
+        go get sigs.k8s.io/controller-runtime/tools/setup-envtest@latest ;\
+        rm -rf $$SETUP_ENVTEST_TMP_DIR ;\
+        }
+SETUP_ENVTEST=$(GOBIN)/setup-envtest
+else
+SETUP_ENVTEST=$(shell which setup-envtest)
 endif


### PR DESCRIPTION
This removes installing kubebuilder binaries and uses setup-envtest to
install all the necessary envtest helper binaries.

⚠️ target branch of the PR is `reconcilers-dev`.