### PR TITLE
policy: Handle failure due to invalid semver range

### DIFF
--- a/controllers/imagepolicy_controller.go
+++ b/controllers/imagepolicy_controller.go
@@ -48,6 +48,7 @@ import (
 const (
 	ImageRepositoryNotReadyReason = "ImageRepositoryNotReady"
 	AccessDeniedReason            = "AccessDenied"
+	ImagePolicyInvalidReason      = "InvalidPolicy"
 )
 
 const (
@@ -154,6 +155,17 @@ func (r *ImagePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	policer, err := policy.PolicerFromSpec(pol.Spec.Policy)
+	if err != nil {
+		msg := fmt.Sprintf("invalid policy: %s", err.Error())
+		conditions.MarkFalse(
+			&pol,
+			meta.ReadyCondition,
+			ImagePolicyInvalidReason,
+			msg,
+		)
+		log.Error(err, "invalid policy")
+		return ctrl.Result{}, nil
+	}
 
 	var latest string
 	if policer != nil {

--- a/internal/policy/factory.go
+++ b/internal/policy/factory.go
@@ -38,5 +38,8 @@ func PolicerFromSpec(choice imagev1.ImagePolicyChoice) (Policer, error) {
 		return nil, fmt.Errorf("given ImagePolicyChoice object is invalid")
 	}
 
-	return p, err
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
 }

--- a/internal/policy/factory_test.go
+++ b/internal/policy/factory_test.go
@@ -40,4 +40,13 @@ func TestFactory_PolicerFromSpec(t *testing.T) {
 	if err != nil {
 		t.Error("should not return error")
 	}
+
+	// A nil checkable Policer for invalid policy.
+	p, err := PolicerFromSpec(imagev1.ImagePolicyChoice{SemVer: &imagev1.SemVerPolicy{Range: "*-*"}})
+	if err == nil {
+		t.Error("should return error")
+	}
+	if p != nil {
+		t.Error("should be nil")
+	}
 }


### PR DESCRIPTION
This implements the fix in #172 for `reconcilers-dev` with tests in the new test format.


:warning: target branch of the PR is `reconcilers-dev`.