### PR TITLE
Replace deprecated io/ioutil with os

### DIFF
--- a/controllers/secret_test.go
+++ b/controllers/secret_test.go
@@ -18,7 +18,7 @@ package controllers
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -29,7 +29,7 @@ func TestExtractAuthn(t *testing.T) {
 	// the secret in testdata/secret.json was created with kubectl
 	// create secret docker-registry. Test that it can be decoded to
 	// get an authentication value.
-	b, err := ioutil.ReadFile("testdata/secret.json")
+	b, err := os.ReadFile("testdata/secret.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestExtractAuthForURLs(t *testing.T) {
 	}
 
 	for _, test := range testFiles {
-		b, err := ioutil.ReadFile("testdata/" + test.secretFile)
+		b, err := os.ReadFile("testdata/" + test.secretFile)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -95,7 +94,7 @@ var _ = BeforeSuite(func(done Done) {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	badgerDir, err = ioutil.TempDir(os.TempDir(), "badger")
+	badgerDir, err = os.MkdirTemp(os.TempDir(), "badger")
 	Expect(err).ToNot(HaveOccurred())
 	badgerDB, err = badger.Open(badger.DefaultOptions(badgerDir))
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/database/badger_test.go
+++ b/internal/database/badger_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package database
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -82,7 +81,7 @@ func TestGetOnlyFetchesForRepo(t *testing.T) {
 
 func createBadgerDatabase(t *testing.T) *BadgerDatabase {
 	t.Helper()
-	dir, err := ioutil.TempDir(os.TempDir(), "badger")
+	dir, err := os.MkdirTemp(os.TempDir(), "badger")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Remove deprecated calls and replace with suggestions from the deprecation notice.

Issues: 
- https://github.com/fluxcd/flux2/issues/1658
- https://github.com/fluxcd/image-reflector-controller/issues/184