### PR TITLE
Set default observedGeneration to -1

### DIFF
--- a/api/v1beta1/imagepolicy_types.go
+++ b/api/v1beta1/imagepolicy_types.go
@@ -131,7 +131,8 @@ type ImagePolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ImagePolicySpec   `json:"spec,omitempty"`
+	Spec ImagePolicySpec `json:"spec,omitempty"`
+	// +kubebuilder:default={"observedGeneration":-1}
 	Status ImagePolicyStatus `json:"status,omitempty"`
 }
 

--- a/api/v1beta1/imagerepository_types.go
+++ b/api/v1beta1/imagerepository_types.go
@@ -143,7 +143,8 @@ type ImageRepository struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ImageRepositorySpec   `json:"spec,omitempty"`
+	Spec ImageRepositorySpec `json:"spec,omitempty"`
+	// +kubebuilder:default={"observedGeneration":-1}
 	Status ImageRepositoryStatus `json:"status,omitempty"`
 }
 

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
@@ -95,6 +95,8 @@ spec:
             - policy
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: ImagePolicyStatus defines the observed state of ImagePolicy
             properties:
               conditions:
@@ -144,6 +146,7 @@ spec:
                 description: LatestImage gives the first in the list of images scanned by the image repository, when filtered and ordered according to the policy.
                 type: string
               observedGeneration:
+                description: ObservedGeneration is the last reconciled generation.
                 format: int64
                 type: integer
             type: object

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -71,6 +71,8 @@ spec:
                 type: string
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: ImageRepositoryStatus defines the observed state of ImageRepository
             properties:
               canonicalImageName:


### PR DESCRIPTION
This sets the status.observedGeneration field to -1 by default. This is to address issue outlined by https://github.com/fluxcd/flux2/issues/2007. 

Signed-off-by: Tom Huang <tom.huang@weave.works>