### PR TITLE
Elaborate on how to enable autologin for ECR

### DIFF
--- a/docs/spec/v1alpha2/imagerepositories.md
+++ b/docs/spec/v1alpha2/imagerepositories.md
@@ -122,7 +122,7 @@ type ImageRepositoryStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// CannonicalName is the name of the image repository with all the
+	// CanonicalImageName is the name of the image repository with all the
 	// implied bits made explicit; e.g., `docker.io/library/alpine`
 	// rather than `alpine`.
 	// +optional

--- a/docs/spec/v1beta1/imagerepositories.md
+++ b/docs/spec/v1beta1/imagerepositories.md
@@ -61,7 +61,7 @@ type ImageRepositorySpec struct {
 ```
 
 The `Suspend` field can be set to `true` to stop the controller scanning the image repository
-specified; remove the field value or set to `false` to resume scanning.
+specified; remove the field value or set it to `false` to resume scanning.
 
 ### Authentication
 
@@ -98,7 +98,19 @@ patches:
         value: --aws-autologin-for-ecr
 ```
 
-Alternatively, the advice under "Other platforms" below will also work for ECR.
+Alternatively, the advice under ["Other platforms"](https://github.com/fluxcd/image-reflector-controller/blob/main/docs/spec/v1beta1/imagerepositories.md#other-platforms) below will also work for ECR.
+
+> You need to upgrade to Flux version 2 release [v0.19](https://github.com/fluxcd/flux2/releases/tag/v0.19.0) that contains the image-reflector-controller release [v0.13.0](https://github.com/fluxcd/image-reflector-controller/blob/main/CHANGELOG.md#0130).
+
+> [**Release date**: 2021-10-19](https://github.com/fluxcd/image-reflector-controller/blob/main/CHANGELOG.md#0130)
+>
+> This prerelease adds experimental support for automatically getting
+credentials from AWS when scanning an image in [Elastic Container Registry
+(ECR)](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html).
+>
+> Improvements:
+> * Get credentials from AWS ECR when needed
+>  [#174](https://github.com/fluxcd/image-reflector-controller/pull/174)
 
 #### Other platforms
 
@@ -209,7 +221,7 @@ type ImageRepositoryStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// CannonicalName is the name of the image repository with all the
+	// CanonicalName is the name of the image repository with all the
 	// implied bits made explicit; e.g., `docker.io/library/alpine`
 	// rather than `alpine`.
 	// +optional

--- a/docs/spec/v1beta1/imagerepositories.md
+++ b/docs/spec/v1beta1/imagerepositories.md
@@ -77,9 +77,28 @@ For a publicly accessible image repository, you will not need to provide a `secr
 
 When running in [<abbr title="Elastic Kubernetes Service">EKS</abbr>][EKS] and using [<abbr
 title="Elastic Container Registry">ECR</abbr>][ECR] to store images, you should be able to rely on
-the controller retrieving credentials automatically. The controller must be run with the flag
-`--aws-autologin-for-ecr` set for this to work. The advice under "Other platforms" below will also
-work for ECR.
+the controller retrieving credentials automatically.
+
+The `image-reflector-controller` must be run with the flag `--aws-autologin-for-ecr` set for this to work.
+
+This flag can be added by including a patch in the `kustomization.yaml` overlay file in your `flux-system`,
+similar to the process described in [customize Flux manifests][]:
+
+```
+patches:
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: image-reflector-controller
+      namespace: flux-system
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --aws-autologin-for-ecr
+```
+
+Alternatively, the advice under "Other platforms" below will also work for ECR.
 
 #### Other platforms
 
@@ -261,3 +280,4 @@ and reference it under `secretRef`.
 [sops-guide]: https://toolkit.fluxcd.io/guides/mozilla-sops/
 [EKS]: https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html
 [ECR]: https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html
+[customize Flux manifests]: https://fluxcd.io/docs/installation/#customize-flux-manifests

--- a/docs/spec/v1beta1/imagerepositories.md
+++ b/docs/spec/v1beta1/imagerepositories.md
@@ -98,19 +98,19 @@ patches:
         value: --aws-autologin-for-ecr
 ```
 
-Alternatively, the advice under ["Other platforms"](https://github.com/fluxcd/image-reflector-controller/blob/main/docs/spec/v1beta1/imagerepositories.md#other-platforms) below will also work for ECR.
+Alternatively, the advice under [Other platforms][other platforms] below will also work for ECR.
 
-> You need to upgrade to Flux version 2 release [v0.19](https://github.com/fluxcd/flux2/releases/tag/v0.19.0) that contains the image-reflector-controller release [v0.13.0](https://github.com/fluxcd/image-reflector-controller/blob/main/CHANGELOG.md#0130).
+> You need to upgrade to Flux version 2 release [v0.19][Flux v0.19.0] that contains the image-reflector-controller release [v0.13.0][image-reflector-controller v0.13.0].
 
-> [**Release date**: 2021-10-19](https://github.com/fluxcd/image-reflector-controller/blob/main/CHANGELOG.md#0130)
+> [**Release date**: 2021-10-19][image-reflector-controller v0.13.0]
 >
 > This prerelease adds experimental support for automatically getting
 credentials from AWS when scanning an image in [Elastic Container Registry
-(ECR)](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html).
+(ECR)][ECR].
 >
 > Improvements:
 > * Get credentials from AWS ECR when needed
->  [#174](https://github.com/fluxcd/image-reflector-controller/pull/174)
+>  [#174][image-reflector-controller#174]
 
 #### Other platforms
 
@@ -293,3 +293,7 @@ and reference it under `secretRef`.
 [EKS]: https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html
 [ECR]: https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html
 [customize Flux manifests]: https://fluxcd.io/docs/installation/#customize-flux-manifests
+[other platforms]: https://fluxcd.io/docs/components/image/imagerepositories/#other-platforms
+[Flux v0.19.0]: https://github.com/fluxcd/flux2/releases/tag/v0.19.0
+[image-reflector-controller v0.13.0]: https://github.com/fluxcd/image-reflector-controller/blob/main/CHANGELOG.md#0130
+[image-reflector-controller#174]: https://github.com/fluxcd/image-reflector-controller/pull/174

--- a/docs/spec/v1beta1/imagerepositories.md
+++ b/docs/spec/v1beta1/imagerepositories.md
@@ -221,7 +221,7 @@ type ImageRepositoryStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// CanonicalName is the name of the image repository with all the
+	// CanonicalImageName is the name of the image repository with all the
 	// implied bits made explicit; e.g., `docker.io/library/alpine`
 	// rather than `alpine`.
 	// +optional


### PR DESCRIPTION
Fixes fluxcd/website#601

There is not enough context in the documentation for `--aws-autologin-for-ecr` to guarantee that a new user who finds this section of the doc will be able to figure out where or how to add this flag to the `image-reflector-controller`.

Provide an example `patches` directive and be sure to say more explicitly which controller accepts this flag. (It is not at all obvious which controller owns the documentation at this URL, even though it has been pulled from this repo, there is no breadcrumb at all or anything else which says "image reflector controller")

https://fluxcd.io/docs/components/image/imagerepositories/#ecr-and-eks