### PR TITLE
Watched cross-ns image repos trigger reconcile

### DIFF
--- a/controllers/imagepolicy_controller.go
+++ b/controllers/imagepolicy_controller.go
@@ -259,8 +259,7 @@ func (r *ImagePolicyReconciler) SetupWithManager(mgr ctrl.Manager, opts ImagePol
 func (r *ImagePolicyReconciler) imagePoliciesForRepository(obj client.Object) []reconcile.Request {
 	ctx := context.Background()
 	var policies imagev1.ImagePolicyList
-	if err := r.List(ctx, &policies, client.InNamespace(obj.GetNamespace()),
-		client.MatchingFields{imageRepoKey: obj.GetName()}); err != nil {
+	if err := r.List(ctx, &policies, client.MatchingFields{imageRepoKey: obj.GetName()}); err != nil {
 		return nil
 	}
 	reqs := make([]reconcile.Request, len(policies.Items))


### PR DESCRIPTION
Cross-namespace ImageRepository resources should trigger reconciles for
ImagePolicies that refer to them. Previously, this was only done for
resources in the same namespace.

Fixes #195