### PR TITLE
Fix watched same-ns image repos trigger reconcile

### DIFF
--- a/controllers/imagepolicy_controller.go
+++ b/controllers/imagepolicy_controller.go
@@ -237,9 +237,14 @@ func (r *ImagePolicyReconciler) SetupWithManager(mgr ctrl.Manager, opts ImagePol
 	// it's easy to list those out when an image repo changes.
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &imagev1.ImagePolicy{}, imageRepoKey, func(obj client.Object) []string {
 		pol := obj.(*imagev1.ImagePolicy)
+
+		namespace := pol.Spec.ImageRepositoryRef.Namespace
+		if namespace == "" {
+			namespace = obj.GetNamespace()
+		}
 		namespacedName := types.NamespacedName{
 			Name:      pol.Spec.ImageRepositoryRef.Name,
-			Namespace: pol.Spec.ImageRepositoryRef.Namespace,
+			Namespace: namespace,
 		}
 		return []string{namespacedName.String()}
 	}); err != nil {

--- a/controllers/policy_test.go
+++ b/controllers/policy_test.go
@@ -386,7 +386,8 @@ var _ = Describe("ImagePolicy controller", func() {
 		When("is in same namespace", func() {
 			It("grants access", func() {
 				versions := []string{"1.0.0", "1.0.1"}
-				imgRepo := loadImages(registryServer, "test-acl-"+randStringRunes(5), versions)
+				imageName := "test-acl-" + randStringRunes(5)
+				imgRepo := loadImages(registryServer, imageName, versions)
 
 				repo := imagev1.ImageRepository{
 					Spec: imagev1.ImageRepositorySpec{
@@ -443,6 +444,19 @@ var _ = Describe("ImagePolicy controller", func() {
 					return err == nil && pol.Status.LatestImage != ""
 				}, timeout, interval).Should(BeTrue())
 				Expect(pol.Status.LatestImage).To(Equal(imgRepo + ":1.0.1"))
+
+				// Updating the image should reconcile the cross-namespace policy
+				imgRepo = loadImages(registryServer, imageName, []string{"1.0.2"})
+				Eventually(func() bool {
+					err := r.Get(ctx, imageObjectName, &repo)
+					return err == nil && repo.Status.LastScanResult.TagCount == len(versions)+1
+				}, timeout, interval).Should(BeTrue())
+
+				Eventually(func() bool {
+					err := r.Get(ctx, polName, &pol)
+					return err == nil && pol.Status.LatestImage != ""
+				}, timeout, interval).Should(BeTrue())
+				Expect(pol.Status.LatestImage).To(Equal(imgRepo + ":1.0.2"))
 
 				Expect(r.Delete(ctx, &pol)).To(Succeed())
 			})


### PR DESCRIPTION
Fixes a regression introduced in v0.13.1

Fixes #198