### PR TITLE
Update Alpine to v3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY internal/ internal/
 ENV CGO_ENABLED=0
 RUN xx-go build -a -o image-reflector-controller main.go
 
-FROM alpine:3.13
+FROM alpine:3.14
 
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/image-reflector-controller"
 


### PR DESCRIPTION
Followup for https://github.com/fluxcd/helm-controller/pull/360.

Unify Alpine minor-version used by container by bumping to 3.14.