### PR TITLE
Clarify ECR Auto-login note, fix CanonicalImageName typos

### DIFF
--- a/docs/spec/v1alpha2/imagerepositories.md
+++ b/docs/spec/v1alpha2/imagerepositories.md
@@ -122,7 +122,7 @@ type ImageRepositoryStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// CannonicalName is the name of the image repository with all the
+	// CanonicalImageName is the name of the image repository with all the
 	// implied bits made explicit; e.g., `docker.io/library/alpine`
 	// rather than `alpine`.
 	// +optional

--- a/docs/spec/v1beta1/imagerepositories.md
+++ b/docs/spec/v1beta1/imagerepositories.md
@@ -86,6 +86,14 @@ the flag is `--gcp-autologin-for-gcr`.
 For [<abbr title="Azure Kubernetes Service">AKS</abbr>][AKS] and [<abbr title="Azure Container Registry">ACR</abbr>][ACR],
 the flag is  `--azure-autologin-for-acr`.
 
+These flags can be added by including a patch in the `kustomization.yaml` overlay file in your `flux-system`,
+as described in [cloud providers authentication guide][]. If there is no need for a security boundary on your
+cluster around container registries and you are not using Flux with so-called "soft multi-tenancy", then
+you will likely prefer to use the Auto-Login feature for the convenience and improved ease of use.
+
+Alternatively, the advice to use a cron job to refresh a secret token under [Other platforms][other platforms]
+below will also work with ECR, GCR, and ACR environments that require security boundaries and soft multi-tenancy.
+
 #### Other platforms
 
 If you are running on another platform that links service permissions to service accounts, you will
@@ -195,7 +203,7 @@ type ImageRepositoryStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// CannonicalName is the name of the image repository with all the
+	// CanonicalImageName is the name of the image repository with all the
 	// implied bits made explicit; e.g., `docker.io/library/alpine`
 	// rather than `alpine`.
 	// +optional
@@ -209,7 +217,7 @@ type ImageRepositoryStatus struct {
 }
 ```
 
-The `CanonicalName` field gives the fully expanded image name, filling in any parts left implicit in
+The `CanonicalImageName` field gives the fully expanded image name, filling in any parts left implicit in
 the spec. For instance, `alpine` expands to `docker.io/library/alpine`.
 
 The `LastScanResult` field gives a summary of the most recent scan:
@@ -270,3 +278,5 @@ and reference it under `secretRef`.
 [GCR]: https://cloud.google.com/container-registry/docs/overview
 [AKS]: https://docs.microsoft.com/en-us/azure/aks/intro-kubernetes
 [ACR]: https://docs.microsoft.com/en-us/azure/container-registry/container-registry-intro
+[cloud providers authentication guide]: https://fluxcd.io/docs/guides/image-update/#imagerepository-cloud-providers-authentication
+[other platforms]: https://fluxcd.io/docs/components/image/imagerepositories/#other-platforms


### PR DESCRIPTION
Leans on:

* #194,
(but I think they can merge in either order)

Slimmed-down replacement version of #193 that takes into account most other things that were to be fixed here, are fixed by fluxcd/website#702

There was a usability issue reported in the docs that I meant to address here, and it's not obvious from the structure of the change, but as the `ImageRepositories` controller API docs are not obviously associated with the `image-reflector-controller` where they are most accessible (on the website, [here](https://fluxcd.io/docs/components/image/imagerepositories/#ecr-and-eks) in the API docs)

There is no breadcrumb which says `image-reflector-controller` visible anywhere on the page, so it's necessary to spell out which controller needs to get the flag.

In fluxcd/website#702 a detailed guide is added that covers ECR, as well as the other cloud providers, and so this PR can omit the example of how to set up the patch in deference to a link to the guide instead. 👍 