### PR TITLE
Fix scheme validation check when using host:port

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -155,8 +155,8 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	var err error
 	var ref name.Reference
-	if u, _ := url.Parse(imageRepo.Spec.Image); u != nil && u.Scheme != "" {
-		err = fmt.Errorf(".spec.image value should not start with URL scheme; remove '%s://'", u.Scheme)
+	if s := strings.Split(imageRepo.Spec.Image, "://"); len(s) > 1 {
+		err = fmt.Errorf(".spec.image value should not start with URL scheme; remove '%s://'", s[0])
 	} else {
 		ref, err = name.ParseReference(imageRepo.Spec.Image)
 	}


### PR DESCRIPTION
The validation check for the presence of a scheme did not take into
account situations when the registry hostname would be accompanied by a
port number. In this situation, the hostname would be erroneously parsed
as a scheme and validation would fail.

Fixes #220