### PR TITLE
Drop capabilities, enable seccomp and enforce runAsNonRoot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ RUN apk add --no-cache ca-certificates tini
 
 COPY --from=builder /workspace/image-reflector-controller /usr/local/bin/
 
-RUN addgroup -S controller && adduser -S controller -G controller
-
-USER controller
+USER 65534:65534
 
 ENTRYPOINT [ "/sbin/tini", "--", "image-reflector-controller" ]

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -29,6 +29,11 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: [ "ALL" ]
+          seccompProfile:
+            type: RuntimeDefault
         ports:
           - containerPort: 8080
             name: http-prom


### PR DESCRIPTION
Further restricts the SecurityContext that the controller runs under, by enabling the default seccomp profile and dropping all linux capabilities.
This was set at container-level to ensure backwards compatibility with use cases in which sidecars are injected into the source-controller pod
without setting less restrictive settings.
Add a uid and gid for the container to enforce runAsNonRoot and ensure
the use of non root users.

BREAKING CHANGES:
1) The use of new seccomp API requires Kubernetes 1.19.
2) the controller container is now executed under 65534:65534 (userid:groupid).
   This change may break deployments that hard-coded the user name 'controller' in their PodSecurityPolicy.
   
Ref: fluxcd/flux2#2014

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>
Co-authored-by: Paulo Gomes <paulo.gomes@weave.works>