### PR TITLE
Move squaremo to retired maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,11 +2,12 @@ The maintainers are generally available in Slack at
 https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages/CLAJ40HV3)
 (obtain an invitation at https://slack.cncf.io/).
 
-In additional to those listed below, this project shares maintainers
-from the main Flux v2 git repository, as listed in
+This project shares maintainers from the main Flux v2 git repository,
+as listed in
 
     https://github.com/fluxcd/flux2/blob/main/MAINTAINERS
 
-In alphabetical order:
+Retired maintainers:
 
-Michael Bridgen, Weaveworks <michael@weave.works> (github: @squaremo, slack: Michael Bridgen)
+ - Michael Bridgen
+


### PR DESCRIPTION
This moves me into the "Retired maintainers" category. The format is intended to work with the script https://github.com/fluxcd/community/blob/main/project/get_project_data.
