### PR TITLE
Allow custom port to image registry

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -155,7 +155,8 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	var err error
 	var ref name.Reference
-	if u, _ := url.Parse(imageRepo.Spec.Image); u != nil && u.Scheme != "" {
+	
+	if u, _ := url.Parse(imageRepo.Spec.Image); u != nil && u.Scheme != "" && strings.Contains(url, "://") {
 		err = fmt.Errorf(".spec.image value should not start with URL scheme; remove '%s://'", u.Scheme)
 	} else {
 		ref, err = name.ParseReference(imageRepo.Spec.Image)


### PR DESCRIPTION
The parse method works bad with port without schema.
If applied this commit will permit to use format [path]:[port]/[owner]/[registry] for image spec