### PR TITLE
fix: Invalid Azure Scope

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -687,7 +687,7 @@ func getAzureLoginAuth(ctx context.Context, ref name.Reference) (authn.AuthConfi
 		return authConfig, err
 	}
 	armToken, err := cred.GetToken(ctx, policy.TokenRequestOptions{
-		Scopes: []string{string(arm.AzurePublicCloud)},
+		Scopes: []string{string(arm.AzurePublicCloud) + ".default"},
 	})
 	if err != nil {
 		return authConfig, err


### PR DESCRIPTION
The scope is missing a `/.default` at the end and thereby prevented me from acquiring a valid access token.

Azure requires a full scope and not only the URL to be able to acquire a token. As the flow uses application permissions and not delegate permissions, the scope needs to end in "/.default" as described in https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#request-the-permissions-in-the-app-registration-portal
