### PR TITLE
Refactor registry test code and fix fuzz integration

### DIFF
--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -17,29 +17,25 @@ limitations under the License.
 package controllers
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"net/http"
 	"net/http/httptest"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/registry"
-	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/fluxcd/image-reflector-controller/internal/test"
 )
 
 var _ = Context("Registry handler", func() {
 
 	It("serves a tag list", func() {
-		srv := newRegistryServer()
+		srv := test.NewRegistryServer()
 		defer srv.Close()
 
 		uploadedTags := []string{"tag1", "tag2"}
-		repoString := loadImages(srv, "testimage", uploadedTags)
+		repoString := test.LoadImages(srv, "testimage", uploadedTags)
 		repo, _ := name.NewRepository(repoString)
 
 		tags, err := remote.List(repo)
@@ -47,158 +43,6 @@ var _ = Context("Registry handler", func() {
 		Expect(tags).To(Equal(uploadedTags))
 	})
 })
-
-// ---
-
-// pre-populated db of tags, so it's not necessary to upload images to
-// get results from remote.List.
-var convenientTags = map[string][]string{
-	"convenient": []string{
-		"tag1", "tag2",
-	},
-}
-
-// set up a local registry for testing scanning
-func newRegistryServer() *httptest.Server {
-	regHandler := registry.New()
-	srv := httptest.NewServer(&tagListHandler{
-		registryHandler: regHandler,
-		imagetags:       convenientTags,
-	})
-	return srv
-}
-
-func newAuthenticatedRegistryServer(username, pass string) *httptest.Server {
-	regHandler := registry.New()
-	regHandler = &tagListHandler{
-		registryHandler: regHandler,
-		imagetags:       convenientTags,
-	}
-	regHandler = &authHandler{
-		registryHandler: regHandler,
-		allowedUser:     username,
-		allowedPass:     pass,
-	}
-	srv := httptest.NewServer(regHandler)
-	return srv
-}
-
-// Get the registry part of an image from the registry server
-func registryName(srv *httptest.Server) string {
-	if strings.HasPrefix(srv.URL, "https://") {
-		return strings.TrimPrefix(srv.URL, "https://")
-	} // else assume HTTP
-	return strings.TrimPrefix(srv.URL, "http://")
-}
-
-// loadImages uploads images to the local registry, and returns the
-// image repo
-// name. https://github.com/google/go-containerregistry/blob/v0.1.1/pkg/registry/compatibility_test.go
-// has an example of loading a test registry with a random image.
-func loadImages(srv *httptest.Server, imageName string, versions []string, options ...remote.Option) string {
-	imgRepo := registryName(srv) + "/" + imageName
-	for _, tag := range versions {
-		imgRef, err := name.NewTag(imgRepo + ":" + tag)
-		Expect(err).ToNot(HaveOccurred())
-		img, err := random.Image(512, 1)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(remote.Write(imgRef, img, options...)).To(Succeed())
-	}
-	return imgRepo
-}
-
-// the go-containerregistry test registry implementation does not
-// serve /myimage/tags/list. Until it does, I'm adding this handler.
-// NB:
-// - assumes repo name is a single element
-// - assumes no overwriting tags
-
-type tagListHandler struct {
-	registryHandler http.Handler
-	imagetags       map[string][]string
-}
-
-type tagListResult struct {
-	Name string   `json:"name"`
-	Tags []string `json:"tags"`
-}
-
-func (h *tagListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// a tag list request has a path like: /v2/<repo>/tags/list
-	if withoutTagsList := strings.TrimSuffix(r.URL.Path, "/tags/list"); r.Method == "GET" && withoutTagsList != r.URL.Path {
-		repo := strings.TrimPrefix(withoutTagsList, "/v2/")
-		if tags, ok := h.imagetags[repo]; ok {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			result := tagListResult{
-				Name: repo,
-				Tags: tags,
-			}
-			Expect(json.NewEncoder(w).Encode(result)).To(Succeed())
-			println("Requested tags", repo, strings.Join(tags, ", "))
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
-	// record the fact of a PUT to a tag; the path looks like: /v2/<repo>/manifests/<tag>
-	h.registryHandler.ServeHTTP(w, r)
-	if r.Method == "PUT" {
-		pathElements := strings.Split(r.URL.Path, "/")
-		if len(pathElements) == 5 && pathElements[1] == "v2" && pathElements[3] == "manifests" {
-			repo, tag := pathElements[2], pathElements[4]
-			println("Recording tag", repo, tag)
-			h.imagetags[repo] = append(h.imagetags[repo], tag)
-		}
-	}
-}
-
-// there's no authentication in go-containerregistry/pkg/registry;
-// this wrapper adds basic auth to a registry handler. NB: the
-// important thing is to be able to test that the credentials get from
-// the secret to the registry API library; it's assumed that the
-// registry API library does e.g., OAuth2 correctly.  See
-// https://tools.ietf.org/html/rfc7617 regarding basic authentication.
-
-type authHandler struct {
-	allowedUser, allowedPass string
-	registryHandler          http.Handler
-}
-
-// ServeHTTP serves a request which needs authentication.
-func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	authHeader := r.Header.Get("Authorization")
-	if authHeader == "" {
-		w.Header().Add("WWW-Authenticate", `Basic realm="Registry"`)
-		w.WriteHeader(401)
-		return
-	}
-	if !strings.HasPrefix(authHeader, "Basic ") {
-		w.WriteHeader(403)
-		w.Write([]byte(`Authorization header does not being with "Basic "`))
-		return
-	}
-	namePass, err := base64.StdEncoding.DecodeString(authHeader[6:])
-	if err != nil {
-		w.WriteHeader(403)
-		w.Write([]byte(`Authorization header doesn't appear to be base64-encoded`))
-		return
-	}
-	namePassSlice := strings.SplitN(string(namePass), ":", 2)
-	if len(namePassSlice) != 2 {
-		w.WriteHeader(403)
-		w.Write([]byte(`Authorization header doesn't appear to be colon-separated value `))
-		w.Write(namePass)
-		return
-	}
-	if namePassSlice[0] != h.allowedUser || namePassSlice[1] != h.allowedPass {
-		w.WriteHeader(403)
-		w.Write([]byte(`Authorization failed: wrong username or password`))
-		return
-	}
-	h.registryHandler.ServeHTTP(w, r)
-}
 
 var _ = Context("Authentication handler", func() {
 
@@ -208,7 +52,7 @@ var _ = Context("Authentication handler", func() {
 	BeforeEach(func() {
 		username = "user"
 		password = "password1"
-		registryServer = newAuthenticatedRegistryServer(username, password)
+		registryServer = test.NewAuthenticatedRegistryServer(username, password)
 	})
 
 	AfterEach(func() {
@@ -216,14 +60,14 @@ var _ = Context("Authentication handler", func() {
 	})
 
 	It("rejects requests without authentication", func() {
-		repo, err := name.NewRepository(registryName(registryServer) + "/convenient")
+		repo, err := name.NewRepository(test.RegistryName(registryServer) + "/convenient")
 		Expect(err).ToNot(HaveOccurred())
 		_, err = remote.List(repo)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("accepts requests with correct authentication", func() {
-		repo, err := name.NewRepository(registryName(registryServer) + "/convenient")
+		repo, err := name.NewRepository(test.RegistryName(registryServer) + "/convenient")
 		Expect(err).ToNot(HaveOccurred())
 		auth := &authn.Basic{
 			Username: username,

--- a/controllers/tls_test.go
+++ b/controllers/tls_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta1"
+	"github.com/fluxcd/image-reflector-controller/internal/test"
 	"github.com/fluxcd/pkg/apis/meta"
 )
 
@@ -56,9 +57,9 @@ var _ = Context("using TLS certificates", func() {
 	var clientTLSCert tls.Certificate
 
 	BeforeEach(func() {
-		reg := &tagListHandler{
-			registryHandler: registry.New(),
-			imagetags:       map[string][]string{},
+		reg := &test.TagListHandler{
+			RegistryHandler: registry.New(),
+			Imagetags:       map[string][]string{},
 		}
 		srv = httptest.NewUnstartedServer(reg)
 
@@ -161,7 +162,7 @@ var _ = Context("using TLS certificates", func() {
 		pool.AddCert(srv.Certificate())
 		transport.TLSClientConfig.RootCAs = pool
 		transport.TLSClientConfig.Certificates = []tls.Certificate{clientTLSCert}
-		imgRepo := loadImages(srv, "image", []string{"1.0.0"}, remote.WithTransport(transport))
+		imgRepo := test.LoadImages(srv, "image", []string{"1.0.0"}, remote.WithTransport(transport))
 
 		secretName := "tls-secret"
 		tlsSecret := corev1.Secret{

--- a/internal/test/registry.go
+++ b/internal/test/registry.go
@@ -1,0 +1,165 @@
+package test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	. "github.com/onsi/gomega"
+)
+
+// pre-populated db of tags, so it's not necessary to upload images to
+// get results from remote.List.
+var convenientTags = map[string][]string{
+	"convenient": {
+		"tag1", "tag2",
+	},
+}
+
+// set up a local registry for testing scanning
+func NewRegistryServer() *httptest.Server {
+	regHandler := registry.New()
+	srv := httptest.NewServer(&TagListHandler{
+		RegistryHandler: regHandler,
+		Imagetags:       convenientTags,
+	})
+	return srv
+}
+
+func NewAuthenticatedRegistryServer(username, pass string) *httptest.Server {
+	regHandler := registry.New()
+	regHandler = &TagListHandler{
+		RegistryHandler: regHandler,
+		Imagetags:       convenientTags,
+	}
+	regHandler = &AuthHandler{
+		registryHandler: regHandler,
+		allowedUser:     username,
+		allowedPass:     pass,
+	}
+	srv := httptest.NewServer(regHandler)
+	return srv
+}
+
+// Get the registry part of an image from the registry server
+func RegistryName(srv *httptest.Server) string {
+	if strings.HasPrefix(srv.URL, "https://") {
+		return strings.TrimPrefix(srv.URL, "https://")
+	} // else assume HTTP
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+// loadImages uploads images to the local registry, and returns the
+// image repo
+// name. https://github.com/google/go-containerregistry/blob/v0.1.1/pkg/registry/compatibility_test.go
+// has an example of loading a test registry with a random image.
+func LoadImages(srv *httptest.Server, imageName string, versions []string, options ...remote.Option) string {
+	imgRepo := RegistryName(srv) + "/" + imageName
+	for _, tag := range versions {
+		imgRef, err := name.NewTag(imgRepo + ":" + tag)
+		Expect(err).ToNot(HaveOccurred())
+		img, err := random.Image(512, 1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(remote.Write(imgRef, img, options...)).To(Succeed())
+	}
+	return imgRepo
+}
+
+// the go-containerregistry test registry implementation does not
+// serve /myimage/tags/list. Until it does, I'm adding this handler.
+// NB:
+// - assumes repo name is a single element
+// - assumes no overwriting tags
+
+type TagListHandler struct {
+	RegistryHandler http.Handler
+	Imagetags       map[string][]string
+}
+
+type TagListResult struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+func (h *TagListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// a tag list request has a path like: /v2/<repo>/tags/list
+	if withoutTagsList := strings.TrimSuffix(r.URL.Path, "/tags/list"); r.Method == "GET" && withoutTagsList != r.URL.Path {
+		repo := strings.TrimPrefix(withoutTagsList, "/v2/")
+		if tags, ok := h.Imagetags[repo]; ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			result := TagListResult{
+				Name: repo,
+				Tags: tags,
+			}
+			Expect(json.NewEncoder(w).Encode(result)).To(Succeed())
+			println("Requested tags", repo, strings.Join(tags, ", "))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	// record the fact of a PUT to a tag; the path looks like: /v2/<repo>/manifests/<tag>
+	h.RegistryHandler.ServeHTTP(w, r)
+	if r.Method == "PUT" {
+		pathElements := strings.Split(r.URL.Path, "/")
+		if len(pathElements) == 5 && pathElements[1] == "v2" && pathElements[3] == "manifests" {
+			repo, tag := pathElements[2], pathElements[4]
+			println("Recording tag", repo, tag)
+			h.Imagetags[repo] = append(h.Imagetags[repo], tag)
+		}
+	}
+}
+
+// there's no authentication in go-containerregistry/pkg/registry;
+// this wrapper adds basic auth to a registry handler. NB: the
+// important thing is to be able to test that the credentials get from
+// the secret to the registry API library; it's assumed that the
+// registry API library does e.g., OAuth2 correctly.  See
+// https://tools.ietf.org/html/rfc7617 regarding basic authentication.
+
+type AuthHandler struct {
+	allowedUser, allowedPass string
+	registryHandler          http.Handler
+}
+
+// ServeHTTP serves a request which needs authentication.
+func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		w.Header().Add("WWW-Authenticate", `Basic realm="Registry"`)
+		w.WriteHeader(401)
+		return
+	}
+	if !strings.HasPrefix(authHeader, "Basic ") {
+		w.WriteHeader(403)
+		w.Write([]byte(`Authorization header does not being with "Basic "`))
+		return
+	}
+	namePass, err := base64.StdEncoding.DecodeString(authHeader[6:])
+	if err != nil {
+		w.WriteHeader(403)
+		w.Write([]byte(`Authorization header doesn't appear to be base64-encoded`))
+		return
+	}
+	namePassSlice := strings.SplitN(string(namePass), ":", 2)
+	if len(namePassSlice) != 2 {
+		w.WriteHeader(403)
+		w.Write([]byte(`Authorization header doesn't appear to be colon-separated value `))
+		w.Write(namePass)
+		return
+	}
+	if namePassSlice[0] != h.allowedUser || namePassSlice[1] != h.allowedPass {
+		w.WriteHeader(403)
+		w.Write([]byte(`Authorization failed: wrong username or password`))
+		return
+	}
+	h.registryHandler.ServeHTTP(w, r)
+}


### PR DESCRIPTION
[oss-fuzz](https://github.com/google/oss-fuzz) in coverage mode was broken due to duplicate symbols. Refactoring the registry test code and referencing it directly fixes it.