### PR TITLE
Add a finalizer to the ImagePolicy and ImageRepository resources

### DIFF
--- a/api/v1beta1/imagepolicy_types.go
+++ b/api/v1beta1/imagepolicy_types.go
@@ -24,6 +24,7 @@ import (
 )
 
 const ImagePolicyKind = "ImagePolicy"
+const ImagePolicyFinalizer = "finalizers.fluxcd.io"
 
 // ImagePolicySpec defines the parameters for calculating the
 // ImagePolicy

--- a/api/v1beta1/imagerepository_types.go
+++ b/api/v1beta1/imagerepository_types.go
@@ -27,6 +27,7 @@ import (
 )
 
 const ImageRepositoryKind = "ImageRepository"
+const ImageRepositoryFinalizer = "finalizers.fluxcd.io"
 
 // ImageRepositorySpec defines the parameters for scanning an image
 // repository, e.g., `fluxcd/flux`.


### PR DESCRIPTION
Fixes https://github.com/fluxcd/image-reflector-controller/issues/225

This PR adds a finalizer to the ImagePolicy and ImageRepository resources. This is to properly record the Deleted reconciliation status when the object is deleted from the cluster. Without this change, the resource would be deleted before the image reflector controller has a chance to properly report the resource's status in the metrics. As a result, end-users may see falsely reported metrics.

Signed-off-by: Kaden Nelson <kaden_l_nelson@apple.com>