### PR TITLE
Validate that the image name does not contain tags

### DIFF
--- a/docs/api/image-reflector.md
+++ b/docs/api/image-reflector.md
@@ -490,7 +490,9 @@ It does not apply to already started scans. Defaults to false.</p>
 <td>
 <code>accessFrom</code><br>
 <em>
+<a href="https://godoc.org/github.com/fluxcd/pkg/apis/acl#AccessFrom">
 github.com/fluxcd/pkg/apis/acl.AccessFrom
+</a>
 </em>
 </td>
 <td>
@@ -660,7 +662,9 @@ It does not apply to already started scans. Defaults to false.</p>
 <td>
 <code>accessFrom</code><br>
 <em>
+<a href="https://godoc.org/github.com/fluxcd/pkg/apis/acl#AccessFrom">
 github.com/fluxcd/pkg/apis/acl.AccessFrom
+</a>
 </em>
 </td>
 <td>

--- a/hack/api-docs/config.json
+++ b/hack/api-docs/config.json
@@ -22,6 +22,10 @@
     {
       "typeMatchPrefix": "^github.com/fluxcd/pkg/apis/meta",
       "docsURLTemplate": "https://godoc.org/github.com/fluxcd/pkg/apis/meta#{{ .TypeIdentifier }}"
+    },
+    {
+      "typeMatchPrefix": "^github.com/fluxcd/pkg/apis/acl",
+      "docsURLTemplate": "https://godoc.org/github.com/fluxcd/pkg/apis/acl#{{ .TypeIdentifier }}"
     }
   ],
   "typeDisplayNamePrefixOverrides": {


### PR DESCRIPTION
Reject image repositories when `.spec.image` contains a tag and set the ready status to:

```
.spec.image value should not contain a tag; remove ':tag'
```

Fix: #267 