### PR TITLE
Fix response body read and close defer order

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -294,8 +294,8 @@ func getGCRLoginAuth(ctx context.Context) (authn.AuthConfig, error) {
 	if err != nil {
 		return authConfig, err
 	}
-	defer io.Copy(io.Discard, response.Body)
 	defer response.Body.Close()
+	defer io.Copy(io.Discard, response.Body)
 
 	if response.StatusCode != http.StatusOK {
 		return authConfig, fmt.Errorf("unexpected status from metadata service: %s", response.Status)


### PR DESCRIPTION
Deferred function calls are executed in Last In First Out order after the surrounding function returns, so we should make sure io.Copy() is executed before close().

Signed-off-by: Soule BA <bah.soule@gmail.com>