### PR TITLE
cloud-provider-e2e: Use test image-reflector build

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -5,25 +5,23 @@ TEST_TIMEOUT ?= 30m
 FLUX_MANIFEST_URL ?= https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
 INSTALL_MANIFEST_PATH ?= build/flux/install.yaml
 
-IMG ?= fluxcd/image-reflector-controller
+# image-reflector-controller test image.
+TEST_IMG ?= fluxcd/image-reflector-controller:dev
 
 $(INSTALL_MANIFEST_PATH):
 	mkdir -p build/flux
 	curl -Lo $(INSTALL_MANIFEST_PATH) $(FLUX_MANIFEST_URL)
-
-# Build the manifests required in the test.
-build-manifests: $(INSTALL_MANIFEST_PATH)
-	cp kustomization.yaml build/flux
-	cd build/flux && kustomize edit set image fluxcd/image-reflector-controller=${IMG}
-	kustomize build build/flux > build/flux.yaml
 
 # Delete all the build files.
 distclean:
 	rm -r build/
 
 # Builds manifests and run the tests.
-test: build-manifests
-	go test -timeout $(TEST_TIMEOUT) -v $(GO_TEST_PATH) $(GO_TEST_ARGS) $(PROVIDER_ARG)
+test: $(INSTALL_MANIFEST_PATH)
+	# Check if the image exists locally.
+	docker image inspect $(TEST_IMG) >/dev/null
+	cp kustomization.yaml build/flux
+	TEST_IMG=$(TEST_IMG) go test -timeout $(TEST_TIMEOUT) -v $(GO_TEST_PATH) $(GO_TEST_ARGS) $(PROVIDER_ARG)
 
 test-aws:
 	$(MAKE) test PROVIDER_ARG="-provider aws"

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -38,10 +38,16 @@ deleted manually.
 Copy `.env.sample` to `.env`, put the respective provider configurations in the
 environment variables and source it, `source .env`.
 
-Run the test with `make test-*`:
+Ensure the image-reflector-controller container image to be tested is built and
+ready for testing. A development image can be built from the root of the project
+by running the make target `docker-build`. Or, a release image can also be
+downloaded and used for testing.
+
+Run the test with `make test-*`, setting the image-reflector image, built or
+downloaded, with variable `TEST_IMG`:
 
 ```console
-$ make test-aws
+$ make test-aws TEST_IMG=foo/image-reflector-controller:dev
 mkdir -p build/flux
 curl -Lo build/flux/install.yaml https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
@@ -54,10 +60,12 @@ go test -timeout 20m -v ./... -existing
 2022/06/15 01:55:09 Terraform binary:  /go/src/github.com/fluxcd/image-reflector-controller/tests/integration/build/terraform
 2022/06/15 01:55:09 Init Terraform
 2022/06/15 01:55:14 Applying Terraform
+2022/06/15 01:55:21 pushing flux test image foo111.dkr.ecr.us-east-2.amazonaws.com/flux-test-image-reflector-direct-elephant:test
 2022/06/15 01:55:41 pushing test image foo111.dkr.ecr.us-east-2.amazonaws.com/flux-image-automation-test:v0.1.0
 2022/06/15 01:55:45 pushing test image foo111.dkr.ecr.us-east-2.amazonaws.com/flux-image-automation-test:v0.1.2
 2022/06/15 01:55:48 pushing test image foo111.dkr.ecr.us-east-2.amazonaws.com/flux-image-automation-test:v0.1.3
 2022/06/15 01:55:51 pushing test image foo111.dkr.ecr.us-east-2.amazonaws.com/flux-image-automation-test:v0.1.4
+2022/06/15 01:55:54 setting images: [fluxcd/image-reflector-controller=457472006214.dkr.ecr.us-east-2.amazonaws.com/flux-test-image-reflector-direct-elephant:test]
 2022/06/15 01:55:54 Installing flux
 === RUN   TestImageRepositoryScan
 === RUN   TestImageRepositoryScan/ecr
@@ -78,9 +86,9 @@ Then the `kustomization.yaml` is copied to `build/flux/`. This kustomization
 contains configurations to configure the flux installation by patching the
 downloaded `install.yaml`. It can also be used to set any custom images for any
 of the flux components. The image-reflector-controller image can be configured
-by setting the `IMG` variable when running the test. The kustomization is built
-and the resulting flux installation manifest is written to `build/flux.yaml`.
-This is used by the test to install flux.
+by setting the `TEST_IMG` variable when running the test. The kustomization is
+built and the resulting flux installation manifest is written to
+`build/flux.yaml`.  This is used by the test to install flux.
 
 The go test is started with a long timeout because the infrastructure set up
 can take a long time. It can also be configured by setting the variable
@@ -110,25 +118,25 @@ For debugging environment provisioning, enable verbose output with `-verbose`
 test flag.
 
 ```console
-$ make test-aws GO_TEST_ARGS="-verbose"
+$ make test-aws GO_TEST_ARGS="-verbose" TEST_IMG=foo/image-reflector-controller:dev
 ```
 
 The test environment is destroyed at the end by default. Run the tests with
 `-retain` flag to retain the created test infrastructure.
 
 ```console
-$ make test-aws GO_TEST_ARGS="-retain"
+$ make test-aws GO_TEST_ARGS="-retain" TEST_IMG=foo/image-reflector-controller:dev
 ```
 
 The tests require the infrastructure state to be clean. For re-running the tests
 with a retained infrastructure, set `-existing` flag.
 
 ```console
-$ make test-aws GO_TEST_ARGS="-retain -existing"
+$ make test-aws GO_TEST_ARGS="-retain -existing" TEST_IMG=foo/image-reflector-controller:dev
 ```
 
 To delete an existing infrastructure created with `-retain` flag:
 
 ```console
-$ make test-aws GO_TEST_ARGS="-existing"
+$ make test-aws GO_TEST_ARGS="-existing" TEST_IMG=foo/image-reflector-controller:dev
 ```

--- a/tests/integration/azure_test.go
+++ b/tests/integration/azure_test.go
@@ -59,3 +59,12 @@ func registryLoginACR(ctx context.Context, output map[string]*tfjson.StateOutput
 	}
 	return map[string]string{"acr": registryURL + "/" + randStringRunes(5)}, nil
 }
+
+// pushFluxTestImagesACR pushes flux images that are being tested. It must be
+// called after registryLoginACR to ensure the local docker client is already
+// logged in and is capable of pushing the test images.
+func pushFluxTestImagesACR(ctx context.Context, localImgs map[string]string, output map[string]*tfjson.StateOutput) (map[string]string, error) {
+	// Get the registry name and construct the image names accordingly.
+	repo := output["acr_registry_url"].Value.(string)
+	return retagAndPush(ctx, repo, localImgs)
+}

--- a/tests/integration/terraform/aws/ecr.tf
+++ b/tests/integration/terraform/aws/ecr.tf
@@ -3,3 +3,9 @@ resource "aws_ecr_repository" "testrepo" {
   image_tag_mutability = "MUTABLE"
   force_delete         = true
 }
+
+resource "aws_ecr_repository" "image_reflector_controller" {
+  name                 = "flux-test-image-reflector-${random_pet.suffix.id}"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+}

--- a/tests/integration/terraform/aws/outputs.tf
+++ b/tests/integration/terraform/aws/outputs.tf
@@ -30,3 +30,7 @@ output "ecr_repository_url" {
 output "ecr_registry_id" {
   value = aws_ecr_repository.testrepo.registry_id
 }
+
+output "ecr_image_reflector_controller_repo_url" {
+  value = aws_ecr_repository.image_reflector_controller.repository_url
+}


### PR DESCRIPTION
Update the cloud provider e2e test suite to take the image-reflector-controller
build to be tested using the variable `TEST_IMG`. This test image must be
built locally before running the e2e tests. In the e2e tests, this local image
is re-tagged and pushed into a remote registry and is used in flux deployment.

For Google Artifact Registry and Azure Container Registry, the
previously created test registries are reused to push the
image-reflector image. But for ECR, a new repository is created due to
lack of support for dynamic repositories.