### PR TITLE
Skip error policy reconciliation if no tags are found

### DIFF
--- a/controllers/imagepolicy_controller.go
+++ b/controllers/imagepolicy_controller.go
@@ -182,6 +182,14 @@ func (r *ImagePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		var tags []string
 		tags, err = r.Database.Tags(repo.Status.CanonicalImageName)
 		if err == nil {
+			if len(tags) == 0 {
+				msg := fmt.Sprintf("no tags found in local storage for '%s'", repo.Name)
+				r.event(ctx, pol, events.EventSeverityInfo, msg)
+				log.Info(msg)
+
+				return ctrl.Result{}, nil
+			}
+
 			var filter *policy.RegexFilter
 			if pol.Spec.FilterTags != nil {
 				filter, err = policy.NewRegexFilter(pol.Spec.FilterTags.Pattern, pol.Spec.FilterTags.Extract)


### PR DESCRIPTION
At controller restart, it is quite common to experience `Cannot determine latest tag for policy: version list argument cannot be empty` errors. This happens because the existing repository may be Ready, but all its underlying data has been lost as it resides in the controller. 

Instead of erroring, this PR tries to self-heal by postponing the Policy reconciliation based on its repository set interval.

As a result, the controller will log:
`
{"level":"info","ts":"2022-08-08T17:37:52.544Z","logger":"controller.imagepolicy","msg":"no tags found in 'my-image-policy', retrying in 1m0s","reconciler group":"image.toolkit.fluxcd.io","reconciler kind":"ImagePolicy","name":"source-controller","namespace":"flux-system"}
`

And generate a Kubernetes Event with similar information.


Fixes: https://github.com/fluxcd/image-reflector-controller/issues/299
