### PR TITLE
fuzz: Fuzz optimisations

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -13,12 +13,19 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18.x
+    - id: go-env
+      run: |
+        echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"       
     - name: Restore Go cache
       uses: actions/cache@v3
       with:
-        path: /home/runner/work/_temp/_github_home/go/pkg/mod
+        path: ${{ steps.go-env.outputs.go-mod-cache }}
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go
     - name: Smoke test Fuzzers
       run: make fuzz-smoketest

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ fuzz-build:
 	rm -rf $(shell pwd)/build/fuzz/
 	mkdir -p $(shell pwd)/build/fuzz/out/
 
-	docker build . --tag local-fuzzing:latest -f tests/fuzz/Dockerfile.builder
+	docker build . --pull --tag local-fuzzing:latest -f tests/fuzz/Dockerfile.builder
 	docker run --rm \
 		-e FUZZING_LANGUAGE=go -e SANITIZER=address \
 		-e CIFUZZ_DEBUG='True' -e OSS_FUZZ_PROJECT_NAME=fluxcd \

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,8 @@ fuzz-build:
 	docker run --rm \
 		-e FUZZING_LANGUAGE=go -e SANITIZER=address \
 		-e CIFUZZ_DEBUG='True' -e OSS_FUZZ_PROJECT_NAME=fluxcd \
+		-u "0:$(shell id -g)" \
+		-v "$(shell go env GOMODCACHE):/root/go/pkg/mod" \
 		-v "$(shell pwd)/build/fuzz/out":/out \
 		local-fuzzing:latest
 


### PR DESCRIPTION
General optimisations in preparation for converting to Go native fuzz:
- Ensures CI runs on Go 1.18.
- Fix caching path and reuse cache from host.
- Ensure latest oss-fuzz base images are being used.

Relates to https://github.com/fluxcd/flux2/issues/2417.