### PR TITLE
api: add custom validation for v1.Duration types

### DIFF
--- a/api/v1beta1/imagerepository_types.go
+++ b/api/v1beta1/imagerepository_types.go
@@ -37,11 +37,15 @@ type ImageRepositorySpec struct {
 	Image string `json:"image,omitempty"`
 	// Interval is the length of time to wait between
 	// scans of the image repository.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +required
 	Interval metav1.Duration `json:"interval,omitempty"`
 
 	// Timeout for image scanning.
 	// Defaults to 'Interval' duration.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
@@ -54,6 +58,7 @@ type ImageRepositorySpec struct {
 
 	// ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
 	// the image pull if the service account has attached pull secrets.
+	// +kubebuilder:validation:MaxLength=253
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -447,6 +447,7 @@ spec:
               interval:
                 description: Interval is the length of time to wait between scans
                   of the image repository.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               secretRef:
                 description: SecretRef can be given the name of a secret containing
@@ -463,6 +464,7 @@ spec:
                 description: ServiceAccountName is the name of the Kubernetes ServiceAccount
                   used to authenticate the image pull if the service account has attached
                   pull secrets.
+                maxLength: 253
                 type: string
               suspend:
                 description: This flag tells the controller to suspend subsequent
@@ -471,6 +473,7 @@ spec:
                 type: boolean
               timeout:
                 description: Timeout for image scanning. Defaults to 'Interval' duration.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                 type: string
             type: object
           status:


### PR DESCRIPTION
To solve discrepancies between parsing versus validation.

xref: https://github.com/kubernetes/apimachinery/issues/131