### PR TITLE
Remove nsswitch.conf creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,6 @@ FROM alpine:3.16
 
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/image-reflector-controller"
 
-# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
-
 RUN apk add --no-cache ca-certificates tini
 
 COPY --from=builder /workspace/image-reflector-controller /usr/local/bin/


### PR DESCRIPTION
Since 11-11-2022, the alpine:3.16 includes that file on its base image. More information can be found at:
https://git.alpinelinux.org/aports/commit/?id=348653a9ba0701e8e968b3344e72313a9ef334e4