### PR TITLE
ImagePolicy: Add predicates to filter events

### DIFF
--- a/controllers/imagepolicy_controller.go
+++ b/controllers/imagepolicy_controller.go
@@ -28,10 +28,12 @@ import (
 	kuberecorder "k8s.io/client-go/tools/record"
 	"k8s.io/client-go/tools/reference"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -260,7 +262,7 @@ func (r *ImagePolicyReconciler) SetupWithManager(mgr ctrl.Manager, opts ImagePol
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&imagev1.ImagePolicy{}).
+		For(&imagev1.ImagePolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&source.Kind{Type: &imagev1.ImageRepository{}},
 			handler.EnqueueRequestsFromMapFunc(r.imagePoliciesForRepository),


### PR DESCRIPTION
ImagePolicy watcher adds every change to its own kind in the work queue which results in unnecessary multiple reconciliations.
Add a predicate to allow own kind events only on generation change. Other reconcilers in other repositories also use such predicates for the same purpose.

**NOTE:** In the current implementation of ImagePolicy reconciler, there's no logging due to which it's not apparent how many times it reconciled in the background. With the refactor in #311, every ImagePolicy reconciliation logs, which made multiple reconciliations more visible.
For example, creating a new ImagePolicy resulted in:
```json
{"level":"info","ts":"2023-01-03T23:11:46.763+0530","msg":"Latest image tag for 'ghcr.io/stefanprodan/podinfo' resolved to 5.0.3","controller":"imagepolicy","controllerGroup":"image.toolkit.fluxcd.io","controllerKind":"ImagePolicy","ImagePolicy":{"name":"podinfo","namespace":"default"},"namespace":"default","name":"podinfo","reconcileID":"cf5bd588-32a2-44ab-8027-6185e3d91775"}
{"level":"info","ts":"2023-01-03T23:11:46.770+0530","msg":"Latest image tag for 'ghcr.io/stefanprodan/podinfo' resolved to 5.0.3","controller":"imagepolicy","controllerGroup":"image.toolkit.fluxcd.io","controllerKind":"ImagePolicy","ImagePolicy":{"name":"podinfo","namespace":"default"},"namespace":"default","name":"podinfo","reconcileID":"80729b49-a66d-482a-8d2e-9bbd2fc6bcf0"}
{"level":"info","ts":"2023-01-03T23:11:47.514+0530","msg":"Latest image tag for 'ghcr.io/stefanprodan/podinfo' resolved to 5.0.3","controller":"imagepolicy","controllerGroup":"image.toolkit.fluxcd.io","controllerKind":"ImagePolicy","ImagePolicy":{"name":"podinfo","namespace":"default"},"namespace":"default","name":"podinfo","reconcileID":"6046cb8e-8ad6-4a89-82b8-1165ff3c6b85"}
```
With the new predicate:
```json
{"level":"info","ts":"2023-01-04T00:02:40.199+0530","msg":"Latest image tag for 'ghcr.io/stefanprodan/podinfo' resolved to 5.0.3","controller":"imagepolicy","controllerGroup":"image.toolkit.fluxcd.io","controllerKind":"ImagePolicy","ImagePolicy":{"name":"podinfo","namespace":"default"},"namespace":"default","name":"podinfo","reconcileID":"f0fcefe4-2361-4216-a099-eee751b525e8"}
```
Fixing it separately in the main branch to keep the number of specific changes in the refactor branch low.