### PR TITLE
Disable caching of Secrets and ConfigMaps

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package features sets the feature gates that image-reflector-controller
+// supports, and their default states.
+package features
+
+import feathelper "github.com/fluxcd/pkg/runtime/features"
+
+const (
+	// CacheSecretsAndConfigMaps controls whether Secrets and ConfigMaps should
+	// be cached.
+	//
+	// When enabled, it will cache both object types, resulting in increased
+	// memory usage and cluster-wide RBAC permissions (list and watch).
+	CacheSecretsAndConfigMaps = "CacheSecretsAndConfigMaps"
+)
+
+var features = map[string]bool{
+	// CacheSecretsAndConfigMaps
+	// opt-in from v0.24
+	CacheSecretsAndConfigMaps: false,
+}
+
+// FeatureGates contains a list of all supported feature gates and their default
+// values.
+func FeatureGates() map[string]bool {
+	return features
+}
+
+// Enabled verifies whether the feature is enabled or not.
+//
+// This is only a wrapper around the Enabled func in pkg/runtime/features, so
+// callers won't need to import both packages for checking whether a feature is
+// enabled.
+func Enabled(feature string) (bool, error) {
+	return feathelper.Enabled(feature)
+}
+
+// Disable disables the specified feature. If the feature is not present, it's a
+// no-op.
+func Disable(feature string) {
+	if _, ok := features[feature]; ok {
+		features[feature] = false
+	}
+}

--- a/main.go
+++ b/main.go
@@ -22,17 +22,20 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 	flag "github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	crtlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/fluxcd/pkg/runtime/acl"
 	"github.com/fluxcd/pkg/runtime/client"
 	helper "github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/events"
+	feathelper "github.com/fluxcd/pkg/runtime/features"
 	"github.com/fluxcd/pkg/runtime/leaderelection"
 	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/fluxcd/pkg/runtime/metrics"
@@ -43,6 +46,7 @@ import (
 	// +kubebuilder:scaffold:imports
 	"github.com/fluxcd/image-reflector-controller/controllers"
 	"github.com/fluxcd/image-reflector-controller/internal/database"
+	"github.com/fluxcd/image-reflector-controller/internal/features"
 	"github.com/fluxcd/pkg/oci/auth/login"
 )
 
@@ -77,6 +81,7 @@ func main() {
 		azureAutoLogin          bool
 		aclOptions              acl.Options
 		rateLimiterOptions      helper.RateLimiterOptions
+		featureGates            feathelper.FeatureGates
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -96,10 +101,18 @@ func main() {
 	leaderElectionOptions.BindFlags(flag.CommandLine)
 	aclOptions.BindFlags(flag.CommandLine)
 	rateLimiterOptions.BindFlags(flag.CommandLine)
+	featureGates.BindFlags(flag.CommandLine)
 	flag.Parse()
 
 	log := logger.NewLogger(logOptions)
 	ctrl.SetLogger(log)
+
+	err := featureGates.WithLogger(setupLog).
+		SupportedFeatures(features.FeatureGates())
+	if err != nil {
+		setupLog.Error(err, "unable to load feature gates")
+		os.Exit(1)
+	}
 
 	badgerOpts := badger.DefaultOptions(storagePath)
 	badgerOpts.ValueLogFileSize = storageValueLogFileSize
@@ -119,6 +132,16 @@ func main() {
 		watchNamespace = os.Getenv("RUNTIME_NAMESPACE")
 	}
 
+	var disableCacheFor []ctrlclient.Object
+	shouldCache, err := features.Enabled(features.CacheSecretsAndConfigMaps)
+	if err != nil {
+		setupLog.Error(err, "unable to check feature gate "+features.CacheSecretsAndConfigMaps)
+		os.Exit(1)
+	}
+	if !shouldCache {
+		disableCacheFor = append(disableCacheFor, &corev1.Secret{}, &corev1.ConfigMap{})
+	}
+
 	restConfig := client.GetConfigOrDie(clientOptions)
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                        scheme,
@@ -132,6 +155,7 @@ func main() {
 		RetryPeriod:                   &leaderElectionOptions.RetryPeriod,
 		LeaderElectionID:              fmt.Sprintf("%s-leader-election", controllerName),
 		Namespace:                     watchNamespace,
+		ClientDisableCacheFor:         disableCacheFor,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Disable caching of Secrets and ConfigMaps by default. Enable caching using feature gate:
```console
--feature-gates=CacheSecretsAndConfigMaps=true
```

Refer: https://github.com/fluxcd/flux2/issues/3426