### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/controllers/scan_test.go
+++ b/controllers/scan_test.go
@@ -552,7 +552,7 @@ func TestImageRepositoryReconciler_ScanPublicRepos(t *testing.T) {
 		name  string
 		image string
 	}{
-		{"gcr", "k8s.gcr.io/coredns/coredns"},
+		{"k8s", "registry.k8s.io/coredns/coredns"},
 		{"ghcr", "ghcr.io/stefanprodan/podinfo"},
 	}
 


### PR DESCRIPTION
I'm still not sure if I even want to make this change because it's just an integration test but i'm updating it anyways.

Context:
Kubernetes is migrating its image registry from [[k8s.gcr.io](http://k8s.gcr.io/)](http://k8s.gcr.io/) to [[registry.k8s.io](http://registry.k8s.io/)](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.