### PR TITLE
Set controller package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ build/
 data
 
 # CRDs for fuzzing tests.
-internal/controllers/testdata/crd
+internal/controller/testdata/crd

--- a/internal/controller/controllers_fuzzer_test.go
+++ b/internal/controller/controllers_fuzzer_test.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/database.go
+++ b/internal/controller/database.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 // DatabaseWriter implementations record the tags for an image repository.
 type DatabaseWriter interface {

--- a/internal/controller/imagepolicy_controller.go
+++ b/internal/controller/imagepolicy_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/imagepolicy_controller_test.go
+++ b/internal/controller/imagepolicy_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/imagerepository_controller_test.go
+++ b/internal/controller/imagerepository_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/policy_test.go
+++ b/internal/controller/policy_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/scan_test.go
+++ b/internal/controller/scan_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func main() {
 
 	metricsH := helper.MustMakeMetrics(mgr)
 
-	if err := (&controllers.ImageRepositoryReconciler{
+	if err := (&controller.ImageRepositoryReconciler{
 		Client:         mgr.GetClient(),
 		EventRecorder:  eventRecorder,
 		Metrics:        metricsH,
@@ -215,20 +215,20 @@ func main() {
 			AzureAutoLogin: azureAutoLogin,
 			GcpAutoLogin:   gcpAutoLogin,
 		},
-	}).SetupWithManager(mgr, controllers.ImageRepositoryReconcilerOptions{
+	}).SetupWithManager(mgr, controller.ImageRepositoryReconcilerOptions{
 		RateLimiter: helper.GetRateLimiter(rateLimiterOptions),
 	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", imagev1.ImageRepositoryKind)
 		os.Exit(1)
 	}
-	if err := (&controllers.ImagePolicyReconciler{
+	if err := (&controller.ImagePolicyReconciler{
 		Client:         mgr.GetClient(),
 		EventRecorder:  eventRecorder,
 		Metrics:        metricsH,
 		Database:       db,
 		ACLOptions:     aclOptions,
 		ControllerName: controllerName,
-	}).SetupWithManager(mgr, controllers.ImagePolicyReconcilerOptions{
+	}).SetupWithManager(mgr, controller.ImagePolicyReconcilerOptions{
 		RateLimiter: helper.GetRateLimiter(rateLimiterOptions),
 	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", imagev1.ImagePolicyKind)


### PR DESCRIPTION
Set package name in the files under internal/controller to have the base name of the directory.
This style is recommended by go and certain text editors/IDEs get confused when the names don't match.

Follow-up of https://github.com/fluxcd/image-reflector-controller/pull/379/commits/dd6f8b073823968abe46dd46d71b1e6e33250cb7 .