### PR TITLE
tests/int: Update aws config for tags

### DIFF
--- a/tests/integration/terraform/aws/main.tf
+++ b/tests/integration/terraform/aws/main.tf
@@ -1,4 +1,14 @@
-provider "aws" {}
+module "tags" {
+  source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/utils/tags"
+
+  tags = var.tags
+}
+
+provider "aws" {
+  default_tags {
+    tags = module.tags.tags
+  }
+}
 
 resource "random_pet" "suffix" {}
 
@@ -10,19 +20,17 @@ module "eks" {
   source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/aws/eks"
 
   name = local.name
-  tags = var.tags
+  tags = module.tags.tags
 }
 
 module "test_ecr" {
   source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/aws/ecr"
 
   name = "test-repo-${local.name}"
-  tags = var.tags
 }
 
 module "image_reflector_ecr" {
   source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/aws/ecr"
 
   name = "test-image-reflector-${local.name}"
-  tags = var.tags
 }


### PR DESCRIPTION
Depends on https://github.com/fluxcd/test-infra/pull/14.

Configure the aws resource tags in the root module.

This will allow to have multiple provider configurations with different regions that can be passed to the aws modules to create resources in different regions.