### PR TITLE
Align docs structure with other controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ manifests: controller-gen
 
 # Generate API reference documentation
 api-docs: gen-crd-api-reference-docs
-	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir=./api/v1beta2 -config=./hack/api-docs/config.json -template-dir=./hack/api-docs/template -out-file=./docs/api/image-reflector.md
+	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir=./api/v1beta2 -config=./hack/api-docs/config.json -template-dir=./hack/api-docs/template -out-file=./docs/api/v1beta2/image-reflector.md
 
 # Run go mod tidy
 tidy:

--- a/docs/api/v1beta2/image-reflector.md
+++ b/docs/api/v1beta2/image-reflector.md
@@ -1,4 +1,4 @@
-<h1>Image reflector API reference</h1>
+<h1>Image reflector API reference v1beta2</h1>
 <p>Packages:</p>
 <ul class="simple">
 <li>

--- a/docs/spec/v1beta2/imagepolicies.md
+++ b/docs/spec/v1beta2/imagepolicies.md
@@ -1,5 +1,7 @@
 # Image Policies
 
+<!-- menuweight:20 -->
+
 The `ImagePolicies` API defines rules for selecting a "latest" image from
 `ImageRepositories`.
 

--- a/docs/spec/v1beta2/imagerepositories.md
+++ b/docs/spec/v1beta2/imagerepositories.md
@@ -1,5 +1,7 @@
 # Image Repositories
 
+<!-- menuweight:30 -->
+
 The `ImageRepository` API defines a repository to scan and store a specific set
 of tags in a database.
 

--- a/hack/api-docs/template/pkg.tpl
+++ b/hack/api-docs/template/pkg.tpl
@@ -1,5 +1,10 @@
 {{ define "packages" }}
-    <h1>Image reflector API reference</h1>
+    <h1>Image reflector API reference
+        {{- with (index .packages 0) -}}
+            {{ with (index .GoPackages 0 ) -}}
+                {{ printf " %s" .Name -}}
+            {{ end -}}
+        {{ end }}</h1>
 
     {{ with .packages}}
         <p>Packages:</p>


### PR DESCRIPTION
In some controller we already support multiple API versions at the same time. In order to streamline the docs structure, the necessary changes to do the same in this repo are applied here as well.

refs fluxcd/website#1577
