### PR TITLE
Handle delete before adding finalizer

### DIFF
--- a/internal/controller/imagepolicy_controller.go
+++ b/internal/controller/imagepolicy_controller.go
@@ -179,16 +179,18 @@ func (r *ImagePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.Metrics.RecordDuration(ctx, obj, start)
 	}()
 
-	// Add finalizer first if it doesn't exist to avoid the race condition
-	// between init and delete.
-	if !controllerutil.ContainsFinalizer(obj, imagev1.ImagePolicyFinalizer) {
-		controllerutil.AddFinalizer(obj, imagev1.ImagePolicyFinalizer)
-		return ctrl.Result{Requeue: true}, nil
-	}
-
 	// Examine if the object is under deletion.
 	if !obj.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, obj)
+	}
+
+	// Add finalizer first if it doesn't exist to avoid the race condition
+	// between init and delete.
+	// Note: Finalizers in general can only be added when the deletionTimestamp
+	// is not set.
+	if !controllerutil.ContainsFinalizer(obj, imagev1.ImagePolicyFinalizer) {
+		controllerutil.AddFinalizer(obj, imagev1.ImagePolicyFinalizer)
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Call subreconciler.

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -166,16 +166,18 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		r.Metrics.RecordDuration(ctx, obj, start)
 	}()
 
-	// Add finalizer first if it doesn't exist to avoid the race condition
-	// between init and delete.
-	if !controllerutil.ContainsFinalizer(obj, imagev1.ImageRepositoryFinalizer) {
-		controllerutil.AddFinalizer(obj, imagev1.ImageRepositoryFinalizer)
-		return ctrl.Result{Requeue: true}, nil
-	}
-
 	// Examine if the object is under deletion.
 	if !obj.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, obj)
+	}
+
+	// Add finalizer first if it doesn't exist to avoid the race condition
+	// between init and delete.
+	// Note: Finalizers in general can only be added when the deletionTimestamp
+	// is not set.
+	if !controllerutil.ContainsFinalizer(obj, imagev1.ImageRepositoryFinalizer) {
+		controllerutil.AddFinalizer(obj, imagev1.ImageRepositoryFinalizer)
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Return if the object is suspended.

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/testenv"
@@ -53,6 +54,7 @@ const (
 )
 
 var (
+	k8sClient    client.Client
 	testEnv      *testenv.Environment
 	testBadgerDB *badger.DB
 	ctx          = ctrl.SetupSignalHandler()
@@ -69,6 +71,12 @@ func TestMain(m *testing.M) {
 	testEnv = testenv.New(testenv.WithCRDPath(filepath.Join("..", "..", "config", "crd", "bases")))
 
 	var err error
+	// Initialize a cacheless client for tests that need the latest objects.
+	k8sClient, err = client.New(testEnv.Config, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		panic(fmt.Sprintf("failed to create k8s client: %v", err))
+	}
+
 	var badgerDir string
 	badgerDir, err = os.MkdirTemp("", "badger")
 	if err != nil {


### PR DESCRIPTION
In `Reconcile()` methods, move the object deletion above add finalizer. Finalizers can't be set when an object is being deleted.

Found by @hiddeco while working on helm-controller. Refer https://github.com/kubernetes-sigs/cluster-api/commit/cef1cf1d9312088a785c520f49970b1c609ab9ad .