### PR TITLE
Add a common finalizer for the reconcilers

### DIFF
--- a/api/v1beta2/condition_types.go
+++ b/api/v1beta2/condition_types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package v1beta2
 
+const ImageFinalizer = "finalizers.fluxcd.io"
+
 const (
 	// ImageURLInvalidReason represents the fact that a given repository has an invalid image URL.
 	ImageURLInvalidReason string = "ImageURLInvalid"

--- a/api/v1beta2/imagepolicy_types.go
+++ b/api/v1beta2/imagepolicy_types.go
@@ -22,6 +22,8 @@ import (
 )
 
 const ImagePolicyKind = "ImagePolicy"
+
+// Deprecated: Use ImageFinalizer.
 const ImagePolicyFinalizer = "finalizers.fluxcd.io"
 
 // ImagePolicySpec defines the parameters for calculating the

--- a/api/v1beta2/imagerepository_types.go
+++ b/api/v1beta2/imagerepository_types.go
@@ -26,6 +26,8 @@ import (
 )
 
 const ImageRepositoryKind = "ImageRepository"
+
+// Deprecated: Use ImageFinalizer.
 const ImageRepositoryFinalizer = "finalizers.fluxcd.io"
 
 // ImageRepositorySpec defines the parameters for scanning an image

--- a/internal/controller/imagepolicy_controller.go
+++ b/internal/controller/imagepolicy_controller.go
@@ -188,8 +188,8 @@ func (r *ImagePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// between init and delete.
 	// Note: Finalizers in general can only be added when the deletionTimestamp
 	// is not set.
-	if !controllerutil.ContainsFinalizer(obj, imagev1.ImagePolicyFinalizer) {
-		controllerutil.AddFinalizer(obj, imagev1.ImagePolicyFinalizer)
+	if !controllerutil.ContainsFinalizer(obj, imagev1.ImageFinalizer) {
+		controllerutil.AddFinalizer(obj, imagev1.ImageFinalizer)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -421,7 +421,7 @@ func (r *ImagePolicyReconciler) applyPolicy(ctx context.Context, obj *imagev1.Im
 // reconcileDelete handles the deletion of the object.
 func (r *ImagePolicyReconciler) reconcileDelete(ctx context.Context, obj *imagev1.ImagePolicy) (reconcile.Result, error) {
 	// Remove our finalizer from the list.
-	controllerutil.RemoveFinalizer(obj, imagev1.ImagePolicyFinalizer)
+	controllerutil.RemoveFinalizer(obj, imagev1.ImageFinalizer)
 
 	// Stop reconciliation as the object is being deleted.
 	return ctrl.Result{}, nil

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -173,8 +173,8 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// between init and delete.
 	// Note: Finalizers in general can only be added when the deletionTimestamp
 	// is not set.
-	if !controllerutil.ContainsFinalizer(obj, imagev1.ImageRepositoryFinalizer) {
-		controllerutil.AddFinalizer(obj, imagev1.ImageRepositoryFinalizer)
+	if !controllerutil.ContainsFinalizer(obj, imagev1.ImageFinalizer) {
+		controllerutil.AddFinalizer(obj, imagev1.ImageFinalizer)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -537,7 +537,7 @@ func (r *ImageRepositoryReconciler) scan(ctx context.Context, obj *imagev1.Image
 // reconcileDelete handles the deletion of the object.
 func (r *ImageRepositoryReconciler) reconcileDelete(ctx context.Context, obj *imagev1.ImageRepository) (ctrl.Result, error) {
 	// Remove our finalizer from the list.
-	controllerutil.RemoveFinalizer(obj, imagev1.ImageRepositoryFinalizer)
+	controllerutil.RemoveFinalizer(obj, imagev1.ImageFinalizer)
 
 	// Stop reconciliation as the object is being deleted.
 	return ctrl.Result{}, nil

--- a/internal/controller/scan_test.go
+++ b/internal/controller/scan_test.go
@@ -176,7 +176,7 @@ func TestImageRepositoryReconciler_repositorySuspended(t *testing.T) {
 	repo.Namespace = imageRepoName.Namespace
 
 	// Add finalizer so that reconciliation reaches suspend check.
-	controllerutil.AddFinalizer(&repo, imagev1.ImageRepositoryFinalizer)
+	controllerutil.AddFinalizer(&repo, imagev1.ImageFinalizer)
 
 	builder := fakeclient.NewClientBuilder().WithScheme(testEnv.GetScheme())
 	builder.WithObjects(&repo)

--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	metricsH := helper.NewMetrics(mgr, metrics.MustMakeRecorder(), imagev1.ImageRepositoryFinalizer)
+	metricsH := helper.NewMetrics(mgr, metrics.MustMakeRecorder(), imagev1.ImageFinalizer)
 
 	if err := (&controller.ImageRepositoryReconciler{
 		Client:         mgr.GetClient(),


### PR DESCRIPTION
In https://github.com/fluxcd/image-reflector-controller/pull/430, the new metric helper constructor was provided with ImageRepository finalizer only as the finalizer values are the same for both the reconcilers. This change introduces a common finalizer constant to avoid using one specific kind of finalizer.

Other controllers use a common constant for finalizers. In this repository, we have two separate constants with the same common value for the finalizer. Replace the two finalizer constants with a common finalizer for the controller.
Deprecate the kind specific finalizers from v1beta2 API.