### PR TITLE
test/int: Set exit code 1 on tf destroy failure

### DIFF
--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -181,6 +181,7 @@ func TestMain(m *testing.M) {
 	defer func() {
 		if err := testEnv.Stop(ctx); err != nil {
 			log.Printf("Failed to stop environment: %v", err)
+			exitCode = 1
 		}
 
 		// Log the panic error before exit to surface the cause of panic.


### PR DESCRIPTION
Explicitly set the test program exit code to 1 when terraform destroy fails to delete the infrastructure.

This was observed when GKE clusters failed to delete due to delete protection enabled by default in the latest version of terraform provider google.

Verified the same fix in https://github.com/fluxcd/pkg/pull/682 .