### PR TITLE
imagerepo: add `.spec.insecure` to `ImageRepository`

### DIFF
--- a/api/v1beta2/imagerepository_types.go
+++ b/api/v1beta2/imagerepository_types.go
@@ -104,6 +104,10 @@ type ImageRepositorySpec struct {
 	// +kubebuilder:default:=generic
 	// +optional
 	Provider string `json:"provider,omitempty"`
+
+	// Insecure allows connecting to a non-TLS HTTP container registry.
+	// +optional
+	Insecure bool `json:"insecure,omitempty"`
 }
 
 type ScanResult struct {

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -315,6 +315,10 @@ spec:
               image:
                 description: Image is the name of the image repository
                 type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS HTTP container
+                  registry.
+                type: boolean
               interval:
                 description: Interval is the length of time to wait between scans
                   of the image repository.

--- a/docs/api/v1beta2/image-reflector.md
+++ b/docs/api/v1beta2/image-reflector.md
@@ -543,6 +543,18 @@ string
 When not specified, defaults to &lsquo;generic&rsquo;.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>insecure</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Insecure allows connecting to a non-TLS HTTP container registry.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -729,6 +741,18 @@ string
 <em>(Optional)</em>
 <p>The provider used for authentication, can be &lsquo;aws&rsquo;, &lsquo;azure&rsquo;, &lsquo;gcp&rsquo; or &lsquo;generic&rsquo;.
 When not specified, defaults to &lsquo;generic&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>insecure</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Insecure allows connecting to a non-TLS HTTP container registry.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/v1beta2/imagerepositories.md
+++ b/docs/spec/v1beta2/imagerepositories.md
@@ -318,6 +318,11 @@ spec:
     - "1.1.1|1.0.0"
 ```
 
+### Insecure
+
+`.spec.insecure` is an optional field to allow connecting to a non-TLS HTTP
+container registry.
+
 ### Provider
 
 `.spec.provider` is an optional field that allows specifying an OIDC provider

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -249,7 +249,7 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 	}
 
 	// Parse image reference.
-	ref, err := parseImageReference(obj.Spec.Image)
+	ref, err := parseImageReference(obj.Spec.Image, obj.Spec.Insecure)
 	if err != nil {
 		conditions.MarkStalled(obj, imagev1.ImageURLInvalidReason, err.Error())
 		result, retErr = ctrl.Result{}, nil
@@ -468,7 +468,7 @@ func (r *ImageRepositoryReconciler) shouldScan(obj imagev1.ImageRepository, now 
 
 	// If the canonical image name of the image is different from the last
 	// observed name, scan now.
-	ref, err := parseImageReference(obj.Spec.Image)
+	ref, err := parseImageReference(obj.Spec.Image, obj.Spec.Insecure)
 	if err != nil {
 		return false, scanInterval, "", err
 	}
@@ -570,13 +570,19 @@ func eventLogf(ctx context.Context, r kuberecorder.EventRecorder, obj runtime.Ob
 }
 
 // parseImageReference parses the given URL into a container registry repository
-// reference.
-func parseImageReference(url string) (name.Reference, error) {
+// reference. If insecure is set to true, then the registry is deemed to be
+// located at an HTTP endpoint.
+func parseImageReference(url string, insecure bool) (name.Reference, error) {
 	if s := strings.Split(url, "://"); len(s) > 1 {
 		return nil, fmt.Errorf(".spec.image value should not start with URL scheme; remove '%s://'", s[0])
 	}
 
-	ref, err := name.ParseReference(url)
+	var opts []name.Option
+	if insecure {
+		opts = append(opts, name.Insecure)
+	}
+
+	ref, err := name.ParseReference(url, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add a new boolean field `.spec.insecure` to the `ImageRepository` API. This enables connecting to insecure registries hosted at an HTTP endpoint.

Fixes #325 
Related to https://github.com/fluxcd/flux2/tree/main/rfcs/0004-insecure-http