### PR TITLE
Add workflow for AWS tests & document the setup

### DIFF
--- a/.github/workflows/integration-aws.yaml
+++ b/.github/workflows/integration-aws.yaml
@@ -29,9 +29,9 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.IRC_E2E_AWS_ACCOUNT_ID }}:role/${{ secrets.IRC_E2E_AWS_ASSUME_ROLE_NAME }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.IRC_E2E_AWS_ASSUME_ROLE_NAME }}
           role-session-name: IRC_GH_Actions
-          aws-region: ${{ vars.IRC_E2E_AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - name: Set up Docker Buildx
@@ -69,9 +69,9 @@ jobs:
       - name: Run tests
         run: . .env && make test-aws TEST_IMG=fluxcd/image-reflector-controller:dev
         env:
-          AWS_REGION: ${{ vars.IRC_E2E_AWS_REGION }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
       - name: Ensure resource cleanup
         if: ${{ always() }}
         run: . .env && make destroy-aws
         env:
-          AWS_REGION: ${{ vars.IRC_E2E_AWS_REGION }}
+          AWS_REGION: ${{ vars.AWS_REGION }}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -274,9 +274,7 @@ module "aws_gh_actions" {
   github_project         = "image-reflector-controller"
   github_repo_branch_ref = "*"
 
-  github_secret_accound_id_name  = "IRC_E2E_AWS_ACCOUNT_ID"
   github_secret_assume_role_name = "IRC_E2E_AWS_ASSUME_ROLE_NAME"
-  github_variable_region_name    = "IRC_E2E_AWS_REGION"
 }
 ```
 


### PR DESCRIPTION
- Add a new workflow `integration-aws` for running the AWS integration tests.
- Add setup docs for configuring the AWS account and GitHub repository for running the tests.

Depends on https://github.com/fluxcd/test-infra/pull/41.

:warning: The AWS and GitHub requirements as documented in the test README under **IAM and CI setup** needs to be fulfilled before or soon after merging this. Else, the CI jobs triggered due to the workflow cron configuration would fail.

Example run: https://github.com/darkowlzz/image-reflector-controller/actions/runs/9274823446/job/25518078639

Part of https://github.com/fluxcd/flux2/issues/4619