### PR TITLE
Fix incorrect use of format strings with the `conditions` package.

### DIFF
--- a/internal/controller/imagepolicy_controller.go
+++ b/internal/controller/imagepolicy_controller.go
@@ -274,7 +274,7 @@ func (r *ImagePolicyReconciler) reconcile(ctx context.Context, sp *patch.SerialP
 		// watched by this reconciler, like the namespace that ImageRepository
 		// allows access from.
 		e := fmt.Errorf("failed to get the referred ImageRepository: %w", err)
-		conditions.MarkFalse(obj, meta.ReadyCondition, reason, e.Error())
+		conditions.MarkFalse(obj, meta.ReadyCondition, reason, "%s", e)
 		result, retErr = ctrl.Result{}, e
 		return
 	}
@@ -296,19 +296,19 @@ func (r *ImagePolicyReconciler) reconcile(ctx context.Context, sp *patch.SerialP
 	if err != nil {
 		// Stall if it's an invalid policy.
 		if _, ok := err.(errInvalidPolicy); ok {
-			conditions.MarkStalled(obj, "InvalidPolicy", err.Error())
+			conditions.MarkStalled(obj, "InvalidPolicy", "%s", err)
 			result, retErr = ctrl.Result{}, nil
 			return
 		}
 
 		// If there's no tag in the database, mark not ready and retry.
 		if err == errNoTagsInDatabase {
-			conditions.MarkFalse(obj, meta.ReadyCondition, imagev1.DependencyNotReadyReason, err.Error())
+			conditions.MarkFalse(obj, meta.ReadyCondition, imagev1.DependencyNotReadyReason, "%s", err)
 			result, retErr = ctrl.Result{}, err
 			return
 		}
 
-		conditions.MarkFalse(obj, meta.ReadyCondition, metav1.StatusFailure, err.Error())
+		conditions.MarkFalse(obj, meta.ReadyCondition, metav1.StatusFailure, "%s", err)
 		result, retErr = ctrl.Result{}, err
 		return
 	}
@@ -330,7 +330,7 @@ func (r *ImagePolicyReconciler) reconcile(ctx context.Context, sp *patch.SerialP
 		prevRef, err := name.NewTag(obj.Status.ObservedPreviousImage)
 		if err != nil {
 			e := fmt.Errorf("failed to parse previous image '%s': %w", obj.Status.ObservedPreviousImage, err)
-			conditions.MarkFalse(obj, meta.ReadyCondition, meta.FailedReason, e.Error())
+			conditions.MarkFalse(obj, meta.ReadyCondition, meta.FailedReason, "%s", e)
 			result, retErr = ctrl.Result{}, e
 		}
 		previousTag = prevRef.TagStr()

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -251,7 +251,7 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 	// Parse image reference.
 	ref, err := parseImageReference(obj.Spec.Image, obj.Spec.Insecure)
 	if err != nil {
-		conditions.MarkStalled(obj, imagev1.ImageURLInvalidReason, err.Error())
+		conditions.MarkStalled(obj, imagev1.ImageURLInvalidReason, "%s", err)
 		result, retErr = ctrl.Result{}, nil
 		return
 	}
@@ -260,7 +260,7 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 	opts, err := r.setAuthOptions(ctx, obj, ref)
 	if err != nil {
 		e := fmt.Errorf("failed to configure authentication options: %w", err)
-		conditions.MarkFalse(obj, meta.ReadyCondition, imagev1.AuthenticationFailedReason, e.Error())
+		conditions.MarkFalse(obj, meta.ReadyCondition, imagev1.AuthenticationFailedReason, "%s", e)
 		result, retErr = ctrl.Result{}, e
 		return
 	}
@@ -269,7 +269,7 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 	ok, when, reasonMsg, err := r.shouldScan(*obj, startTime)
 	if err != nil {
 		e := fmt.Errorf("failed to determine if it's scan time: %w", err)
-		conditions.MarkFalse(obj, meta.ReadyCondition, metav1.StatusFailure, e.Error())
+		conditions.MarkFalse(obj, meta.ReadyCondition, metav1.StatusFailure, "%s", e)
 		result, retErr = ctrl.Result{}, e
 		return
 	}
@@ -286,7 +286,7 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 		tags, err := r.scan(ctx, obj, ref, opts)
 		if err != nil {
 			e := fmt.Errorf("scan failed: %w", err)
-			conditions.MarkFalse(obj, meta.ReadyCondition, imagev1.ReadOperationFailedReason, e.Error())
+			conditions.MarkFalse(obj, meta.ReadyCondition, imagev1.ReadOperationFailedReason, "%s", e)
 			result, retErr = ctrl.Result{}, e
 			return
 		}


### PR DESCRIPTION
The `Mark…` functions in the `conditions` package accept a format string and (optional) arguments, just like `fmt.Printf` and friends.

In many places, the code passed an error message as the format string, causing it to be interpreted as a format string by the `fmt` package. This leads to issues when the message contains percent signs, e.g. URL-encoded values.

This PR adds a format string and shortens `err.Error()` to `err`, which yields the same output.

This change is identical in principle to fluxcd/source-controller#1529.