### PR TITLE
Remove deprecated object metrics

### DIFF
--- a/internal/controller/imagepolicy_controller.go
+++ b/internal/controller/imagepolicy_controller.go
@@ -174,8 +174,7 @@ func (r *ImagePolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			retErr = kerrors.NewAggregate([]error{retErr, err})
 		}
 
-		// Always record readiness and duration metrics.
-		r.Metrics.RecordReadiness(ctx, obj)
+		// Always record duration metrics.
 		r.Metrics.RecordDuration(ctx, obj, start)
 	}()
 

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -161,9 +161,7 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			retErr = kerrors.NewAggregate([]error{retErr, err})
 		}
 
-		// Always record suspend, readiness and duration metrics.
-		r.Metrics.RecordSuspend(ctx, obj, obj.Spec.Suspend)
-		r.Metrics.RecordReadiness(ctx, obj)
+		// Always record duration metrics.
 		r.Metrics.RecordDuration(ctx, obj, start)
 	}()
 


### PR DESCRIPTION
Suspend and readiness metrics recording removed from ImageRepository and ImagePolicy reconcilers.

Refer https://github.com/fluxcd/flux2/issues/5083.