### PR TITLE
Implement BadgerDB garbage collector with mutex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fluxcd/pkg/oci v0.45.0
 	github.com/fluxcd/pkg/runtime v0.53.1
 	github.com/fluxcd/pkg/version v0.6.0
+	github.com/go-logr/logr v1.4.2
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20250115185438-c4dd792fa06c
 	github.com/onsi/ginkgo v1.16.5
@@ -83,7 +84,6 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect

--- a/internal/database/badger_gc.go
+++ b/internal/database/badger_gc.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package database
+
+import (
+	"errors"
+	"time"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/go-logr/logr"
+)
+
+type BadgerGarbageCollector struct {
+	// settings
+	DiscardRatio float64
+	Interval     time.Duration
+	// external deps
+	db  *badger.DB
+	log *logr.Logger
+	// flow control
+	timer *time.Timer
+	stop  chan struct{}
+}
+
+// NewBadgerGarbageCollector creates and returns a new
+func NewBadgerGarbageCollector(db *badger.DB, interval time.Duration, log *logr.Logger) *BadgerGarbageCollector {
+	return &BadgerGarbageCollector{
+		DiscardRatio: 0.5, // must be a float between 0.0 and 1.0, inclusive
+		Interval:     interval,
+
+		db:  db,
+		log: log,
+
+		timer: time.NewTimer(interval),
+		stop:  make(chan struct{}),
+	}
+}
+
+// Run repeatedly runs the BadgerDB garbage collector with a delay inbetween
+// runs.
+//
+// This is a blocking operation, so it should be run as a separate goroutine.
+// To stop the garbage collector, call Stop().
+func (gc *BadgerGarbageCollector) Run() {
+	gc.log.Info("Starting Badger GC")
+	for {
+		select {
+		case <-gc.timer.C:
+			gc.discardValueLogFiles()
+			gc.timer.Reset(gc.Interval)
+		case <-gc.stop:
+			gc.timer.Stop()
+			gc.log.Info("Stopped Badger GC")
+			gc.stop <- struct{}{}
+			return
+		}
+	}
+}
+
+// Stop blocks until the garbage collector has been stopped.
+//
+// To avoid GC Errors, call Stop() before closing the database.
+func (gc *BadgerGarbageCollector) Stop() {
+	gc.log.Info("Sending stop to Badger GC")
+	gc.stop <- struct{}{}
+	<-gc.stop
+}
+
+// upper bound for loop
+const maxDiscards = 1000
+
+func (gc *BadgerGarbageCollector) discardValueLogFiles() {
+	for c := 0; c < maxDiscards; c++ {
+		err := gc.db.RunValueLogGC(gc.DiscardRatio)
+		if errors.Is(err, badger.ErrNoRewrite) {
+			// there is no more garbage to discard
+			gc.log.Info("Ran Badger GC", "discarded_vlogs", c)
+			return
+		}
+		if err != nil {
+			gc.log.Error(err, "Badger GC Error", "discarded_vlogs", c)
+			return
+		}
+	}
+	gc.log.Info("Ran Badger GC for maximum discards", "discarded_vlogs", maxDiscards)
+}

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 	defer badgerDB.Close()
 
 	badgerGC := database.NewBadgerGarbageCollector(badgerDB, 1*time.Minute, &gcLog)
-	go badgerGC.Run()
+	badgerGC.Start()
 	defer badgerGC.Stop()
 
 	db := database.NewBadgerDatabase(badgerDB)


### PR DESCRIPTION
Functionally, this is similar to #757 but implemented with a Mutex instead.

See the diff from the second commit in this PR.

Perhaps this is a more legible way of handling the GC state.
It does also give us some other options for yeilding the GC to the controller's signal interrupt.

Related #748
