### PR TITLE
Store checksum of ImageRepository tags and trigger ImagePolicy watch only when it changes

### DIFF
--- a/api/v1beta2/imagerepository_types.go
+++ b/api/v1beta2/imagerepository_types.go
@@ -28,6 +28,7 @@ import (
 const ImageRepositoryKind = "ImageRepository"
 
 // Deprecated: Use ImageFinalizer.
+// TODO: Remove in v1.
 const ImageRepositoryFinalizer = ImageFinalizer
 
 // ImageRepositorySpec defines the parameters for scanning an image
@@ -115,10 +116,26 @@ type ImageRepositorySpec struct {
 	Insecure bool `json:"insecure,omitempty"`
 }
 
+// ScanResult contains information about the last scan of the image repository.
+// TODO: Make all fields except for LatestTags required in v1.
 type ScanResult struct {
-	TagCount   int         `json:"tagCount"`
-	ScanTime   metav1.Time `json:"scanTime,omitempty"`
-	LatestTags []string    `json:"latestTags,omitempty"`
+	// Revision is a stable hash of the scanned tags.
+	// +optional
+	Revision string `json:"revision"`
+
+	// TagCount is the number of tags found in the last scan.
+	// +required
+	TagCount int `json:"tagCount"`
+
+	// ScanTime is the time when the last scan was performed.
+	// +optional
+	ScanTime metav1.Time `json:"scanTime"`
+
+	// LatestTags is a small sample of the tags found in the last scan.
+	// It's the first 10 tags when sorting all the tags in descending
+	// alphabetical order.
+	// +optional
+	LatestTags []string `json:"latestTags,omitempty"`
 }
 
 // ImageRepositoryStatus defines the observed state of ImageRepository

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -483,13 +483,23 @@ spec:
                 description: LastScanResult contains the number of fetched tags.
                 properties:
                   latestTags:
+                    description: |-
+                      LatestTags is a small sample of the tags found in the last scan.
+                      It's the first 10 tags when sorting all the tags in descending
+                      alphabetical order.
                     items:
                       type: string
                     type: array
+                  revision:
+                    description: Revision is a stable hash of the scanned tags.
+                    type: string
                   scanTime:
+                    description: ScanTime is the time when the last scan was performed.
                     format: date-time
                     type: string
                   tagCount:
+                    description: TagCount is the number of tags found in the last
+                      scan.
                     type: integer
                 required:
                 - tagCount

--- a/docs/api/v1beta2/image-reflector.md
+++ b/docs/api/v1beta2/image-reflector.md
@@ -1098,6 +1098,8 @@ would select 0.</p>
 (<em>Appears on:</em>
 <a href="#image.toolkit.fluxcd.io/v1beta2.ImageRepositoryStatus">ImageRepositoryStatus</a>)
 </p>
+<p>ScanResult contains information about the last scan of the image repository.
+TODO: Make all fields except for LatestTags required in v1.</p>
 <div class="md-typeset__scrollwrap">
 <div class="md-typeset__table">
 <table>
@@ -1110,12 +1112,25 @@ would select 0.</p>
 <tbody>
 <tr>
 <td>
+<code>revision</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Revision is a stable hash of the scanned tags.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tagCount</code><br>
 <em>
 int
 </em>
 </td>
 <td>
+<p>TagCount is the number of tags found in the last scan.</p>
 </td>
 </tr>
 <tr>
@@ -1128,6 +1143,8 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>ScanTime is the time when the last scan was performed.</p>
 </td>
 </tr>
 <tr>
@@ -1138,6 +1155,10 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>LatestTags is a small sample of the tags found in the last scan.
+It&rsquo;s the first 10 tags when sorting all the tags in descending
+alphabetical order.</p>
 </td>
 </tr>
 </tbody>

--- a/internal/controller/database.go
+++ b/internal/controller/database.go
@@ -18,7 +18,7 @@ package controller
 
 // DatabaseWriter implementations record the tags for an image repository.
 type DatabaseWriter interface {
-	SetTags(repo string, tags []string) error
+	SetTags(repo string, tags []string) (string, error)
 }
 
 // DatabaseReader implementations get the stored set of tags for an image

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -21,7 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"sort"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -190,7 +191,8 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 	obj *imagev1.ImageRepository, startTime time.Time) (result ctrl.Result, retErr error) {
 	oldObj := obj.DeepCopy()
 
-	var foundTags int
+	var tagsChecksum string
+	var numFoundTags int
 	// Store a message about current reconciliation and next scan.
 	var nextScanMsg string
 	// Set a default next scan time before processing the object.
@@ -205,7 +207,7 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 			return true
 		}
 
-		readyMsg := fmt.Sprintf("successful scan: found %d tags", foundTags)
+		readyMsg := fmt.Sprintf("successful scan: found %d tags with checksum %s", numFoundTags, tagsChecksum)
 		rs := reconcile.NewResultFinalizer(isSuccess, readyMsg)
 		retErr = rs.Finalize(obj, result, retErr)
 
@@ -300,20 +302,18 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 			return
 		}
 
-		tags, err := r.scan(ctx, obj, ref, opts)
-		if err != nil {
+		if err := r.scan(ctx, obj, ref, opts); err != nil {
 			e := fmt.Errorf("scan failed: %w", err)
 			conditions.MarkFalse(obj, meta.ReadyCondition, imagev1.ReadOperationFailedReason, "%s", e)
 			result, retErr = ctrl.Result{}, e
 			return
 		}
-		foundTags = tags
 
 		nextScanMsg = fmt.Sprintf("next scan in %s", when.String())
 		// Check if new tags were found.
 		if oldObj.Status.LastScanResult != nil &&
-			oldObj.Status.LastScanResult.TagCount == foundTags {
-			nextScanMsg = "no new tags found, " + nextScanMsg
+			oldObj.Status.LastScanResult.Revision == obj.Status.LastScanResult.Revision {
+			nextScanMsg = "tags did not change, " + nextScanMsg
 		} else {
 			// When new tags are found, this message will be suppressed by
 			// another event based on the new Ready=true status value. This is
@@ -321,9 +321,10 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 			nextScanMsg = "successful scan, " + nextScanMsg
 		}
 	} else {
-		foundTags = obj.Status.LastScanResult.TagCount
 		nextScanMsg = fmt.Sprintf("no change in repository configuration since last scan, next scan in %s", when.String())
 	}
+	tagsChecksum = obj.Status.LastScanResult.Revision
+	numFoundTags = obj.Status.LastScanResult.TagCount
 
 	// Set the observations on the status.
 	obj.Status.CanonicalImageName = ref.Context().String()
@@ -409,7 +410,7 @@ func (r *ImageRepositoryReconciler) shouldScan(obj imagev1.ImageRepository, now 
 
 // scan performs repository scanning and writes the scanned result in the
 // internal database and populates the status of the ImageRepository.
-func (r *ImageRepositoryReconciler) scan(ctx context.Context, obj *imagev1.ImageRepository, ref name.Reference, options []remote.Option) (int, error) {
+func (r *ImageRepositoryReconciler) scan(ctx context.Context, obj *imagev1.ImageRepository, ref name.Reference, options []remote.Option) error {
 	timeout := obj.GetTimeout()
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -418,24 +419,30 @@ func (r *ImageRepositoryReconciler) scan(ctx context.Context, obj *imagev1.Image
 
 	tags, err := remote.List(ref.Context(), options...)
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	filteredTags, err := filterOutTags(tags, obj.GetExclusionList())
 	if err != nil {
-		return 0, err
+		return err
+	}
+
+	latestTags := sortTagsAndGetLatestTags(filteredTags)
+	if len(latestTags) == 0 {
+		latestTags = nil // for omission in json serialization when empty
 	}
 
 	canonicalName := ref.Context().String()
-	if err := r.Database.SetTags(canonicalName, filteredTags); err != nil {
-		return 0, fmt.Errorf("failed to set tags for %q: %w", canonicalName, err)
+	checksum, err := r.Database.SetTags(canonicalName, filteredTags)
+	if err != nil {
+		return fmt.Errorf("failed to set tags for %q: %w", canonicalName, err)
 	}
 
-	scanTime := metav1.Now()
 	obj.Status.LastScanResult = &imagev1.ScanResult{
+		Revision:   checksum,
 		TagCount:   len(filteredTags),
-		ScanTime:   scanTime,
-		LatestTags: getLatestTags(filteredTags),
+		ScanTime:   metav1.Now(),
+		LatestTags: latestTags,
 	}
 
 	// If the reconcile request annotation was set, consider it
@@ -445,7 +452,7 @@ func (r *ImageRepositoryReconciler) scan(ctx context.Context, obj *imagev1.Image
 		obj.Status.SetLastHandledReconcileRequest(token)
 	}
 
-	return len(filteredTags), nil
+	return nil
 }
 
 // reconcileDelete handles the deletion of the object.
@@ -507,19 +514,15 @@ func filterOutTags(tags []string, patterns []string) ([]string, error) {
 	return filteredTags, nil
 }
 
-// getLatestTags takes a slice of tags, sorts them in descending order of their
-// values and returns the 10 latest tags.
-func getLatestTags(tags []string) []string {
-	var result []string
-	sort.SliceStable(tags, func(i, j int) bool { return tags[i] > tags[j] })
-
-	if len(tags) >= latestTagsCount {
-		latestTags := tags[0:latestTagsCount]
-		result = append(result, latestTags...)
-	} else {
-		result = append(result, tags...)
-	}
-	return result
+// sortTagsAndGetLatestTags takes a slice of tags, sorts them in-place
+// in descending order of their values and returns the 10 latest tags.
+func sortTagsAndGetLatestTags(tags []string) []string {
+	slices.SortStableFunc(tags, func(a, b string) int { return -strings.Compare(a, b) })
+	latestTags := tags[:min(len(tags), latestTagsCount)]
+	// We can't return a slice of the original slice here because the original
+	// slice can be too large and we want to free up that memory. Our copy has
+	// at most latestTagsCount elements, which is specifically a small number.
+	return slices.Clone(latestTags)
 }
 
 // isEqualSliceContent compares two string slices to check if they have the same

--- a/internal/controller/imagerepository_controller_test.go
+++ b/internal/controller/imagerepository_controller_test.go
@@ -22,8 +22,10 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"hash/adler32"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,12 +58,12 @@ type mockDatabase struct {
 }
 
 // SetTags implements the DatabaseWriter interface of the Database.
-func (db *mockDatabase) SetTags(repo string, tags []string) error {
+func (db *mockDatabase) SetTags(repo string, tags []string) (string, error) {
 	if db.WriteError != nil {
-		return db.WriteError
+		return "", db.WriteError
 	}
 	db.TagData = append(db.TagData, tags...)
-	return nil
+	return fmt.Sprintf("%v", adler32.Checksum([]byte(strings.Join(tags, ",")))), nil
 }
 
 // Tags implements the DatabaseReader interface of the Database.
@@ -277,66 +279,74 @@ func TestImageRepositoryReconciler_scan(t *testing.T) {
 	proxyAddr, proxyPort := test.NewProxy(t)
 
 	tests := []struct {
-		name           string
-		tags           []string
-		exclusionList  []string
-		annotation     string
-		db             *mockDatabase
-		proxyURL       *url.URL
-		wantErr        string
-		wantTags       []string
-		wantLatestTags []string
+		name          string
+		tags          []string
+		exclusionList []string
+		annotation    string
+		db            *mockDatabase
+		proxyURL      *url.URL
+		wantErr       string
+		wantChecksum  string
+		wantTags      []string
 	}{
 		{
 			name:    "no tags",
 			wantErr: "404 Not Found",
 		},
 		{
-			name:           "simple tags",
-			tags:           []string{"a", "b", "c", "d"},
-			db:             &mockDatabase{},
-			wantTags:       []string{"a", "b", "c", "d"},
-			wantLatestTags: []string{"d", "c", "b", "a"},
+			name:     "simple tags",
+			tags:     []string{"a", "b", "c", "d"},
+			db:       &mockDatabase{},
+			wantTags: []string{"d", "c", "b", "a"},
 		},
 		{
-			name:           "simple tags with proxy",
-			tags:           []string{"a", "b", "c", "d"},
-			db:             &mockDatabase{},
-			proxyURL:       &url.URL{Scheme: "http", Host: proxyAddr},
-			wantTags:       []string{"a", "b", "c", "d"},
-			wantLatestTags: []string{"d", "c", "b", "a"},
+			name:         "tags are sorted for checksum - order 1",
+			tags:         []string{"c", "d", "a", "b"},
+			db:           &mockDatabase{},
+			wantChecksum: "139002383",
+			wantTags:     []string{"d", "c", "b", "a"},
 		},
 		{
-			name:           "simple tags with incorrect proxy",
-			tags:           []string{"a", "b", "c", "d"},
-			db:             &mockDatabase{},
-			proxyURL:       &url.URL{Scheme: "http", Host: fmt.Sprintf("localhost:%d", proxyPort+1)},
-			wantErr:        "connection refused",
-			wantTags:       []string{"a", "b", "c", "d"},
-			wantLatestTags: []string{"d", "c", "b", "a"},
+			name:         "tags are sorted for checksum - order 2",
+			tags:         []string{"c", "b", "a", "d"},
+			db:           &mockDatabase{},
+			wantChecksum: "139002383",
+			wantTags:     []string{"d", "c", "b", "a"},
 		},
 		{
-			name:           "simple tags, 10+",
-			tags:           []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"},
-			db:             &mockDatabase{},
-			wantTags:       []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"},
-			wantLatestTags: []string{"k", "j", "i", "h, g, f, e, d, c, b"},
+			name:     "simple tags with proxy",
+			tags:     []string{"a", "b", "c", "d"},
+			db:       &mockDatabase{},
+			proxyURL: &url.URL{Scheme: "http", Host: proxyAddr},
+			wantTags: []string{"d", "c", "b", "a"},
 		},
 		{
-			name:           "with single exclusion pattern",
-			tags:           []string{"a", "b", "c", "d"},
-			exclusionList:  []string{"c"},
-			db:             &mockDatabase{},
-			wantTags:       []string{"a", "b", "d"},
-			wantLatestTags: []string{"d", "b", "a"},
+			name:     "simple tags with incorrect proxy",
+			tags:     []string{"a", "b", "c", "d"},
+			db:       &mockDatabase{},
+			proxyURL: &url.URL{Scheme: "http", Host: fmt.Sprintf("localhost:%d", proxyPort+1)},
+			wantErr:  "connection refused",
+			wantTags: []string{"d", "c", "b", "a"},
 		},
 		{
-			name:           "with multiple exclusion pattern",
-			tags:           []string{"a", "b", "c", "d"},
-			exclusionList:  []string{"c", "a"},
-			db:             &mockDatabase{},
-			wantTags:       []string{"b", "d"},
-			wantLatestTags: []string{"d", "b"},
+			name:     "more than maximum amount of tags for latest tags",
+			tags:     []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"},
+			db:       &mockDatabase{},
+			wantTags: []string{"k", "j", "i", "h", "g", "f", "e", "d", "c", "b", "a"},
+		},
+		{
+			name:          "with single exclusion pattern",
+			tags:          []string{"a", "b", "c", "d"},
+			exclusionList: []string{"c"},
+			db:            &mockDatabase{},
+			wantTags:      []string{"d", "b", "a"},
+		},
+		{
+			name:          "with multiple exclusion pattern",
+			tags:          []string{"a", "b", "c", "d"},
+			exclusionList: []string{"c", "a"},
+			db:            &mockDatabase{},
+			wantTags:      []string{"d", "b"},
 		},
 		{
 			name:          "bad exclusion pattern",
@@ -351,12 +361,11 @@ func TestImageRepositoryReconciler_scan(t *testing.T) {
 			wantErr: "failed to set tags",
 		},
 		{
-			name:           "with reconcile annotation",
-			tags:           []string{"a", "b"},
-			annotation:     "foo",
-			db:             &mockDatabase{},
-			wantTags:       []string{"a", "b"},
-			wantLatestTags: []string{"b", "a"},
+			name:       "with reconcile annotation",
+			tags:       []string{"a", "b"},
+			annotation: "foo",
+			db:         &mockDatabase{},
+			wantTags:   []string{"b", "a"},
 		},
 	}
 
@@ -393,7 +402,7 @@ func TestImageRepositoryReconciler_scan(t *testing.T) {
 				opts = append(opts, remote.WithTransport(tr))
 			}
 
-			tagCount, err := r.scan(context.TODO(), repo, ref, opts)
+			err = r.scan(context.TODO(), repo, ref, opts)
 			if tt.wantErr != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))
@@ -401,10 +410,14 @@ func TestImageRepositoryReconciler_scan(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 			}
 			if err == nil {
-				g.Expect(tagCount).To(Equal(len(tt.wantTags)))
 				g.Expect(r.Database.Tags(imgRepo)).To(Equal(tt.wantTags))
+				if tt.wantChecksum != "" {
+					g.Expect(repo.Status.LastScanResult.Revision).To(Equal(tt.wantChecksum))
+				}
 				g.Expect(repo.Status.LastScanResult.TagCount).To(Equal(len(tt.wantTags)))
 				g.Expect(repo.Status.LastScanResult.ScanTime).ToNot(BeZero())
+				g.Expect(len(repo.Status.LastScanResult.LatestTags)).To(BeNumerically("<=", latestTagsCount))
+				g.Expect(repo.Status.LastScanResult.LatestTags).To(Equal(tt.wantTags[:min(len(tt.wantTags), latestTagsCount)]))
 				if tt.annotation != "" {
 					g.Expect(repo.Status.LastHandledReconcileAt).To(Equal(tt.annotation))
 				}
@@ -413,7 +426,7 @@ func TestImageRepositoryReconciler_scan(t *testing.T) {
 	}
 }
 
-func TestGetLatestTags(t *testing.T) {
+func TestSortTagsAndGetLatestTags(t *testing.T) {
 	tests := []struct {
 		name           string
 		tags           []string
@@ -464,7 +477,7 @@ func TestGetLatestTags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			g.Expect(getLatestTags(tt.tags)).To(Equal(tt.wantLatestTags))
+			g.Expect(sortTagsAndGetLatestTags(tt.tags)).To(Equal(tt.wantLatestTags))
 		})
 	}
 }

--- a/internal/database/badger.go
+++ b/internal/database/badger.go
@@ -18,6 +18,7 @@ package database
 import (
 	"encoding/json"
 	"fmt"
+	"hash/adler32"
 
 	"github.com/dgraph-io/badger/v3"
 )
@@ -54,15 +55,19 @@ func (a *BadgerDatabase) Tags(repo string) ([]string, error) {
 // the repo.
 //
 // It overwrites existing tag sets for the provided repo.
-func (a *BadgerDatabase) SetTags(repo string, tags []string) error {
+func (a *BadgerDatabase) SetTags(repo string, tags []string) (string, error) {
 	b, err := marshal(tags)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return a.db.Update(func(txn *badger.Txn) error {
+	err = a.db.Update(func(txn *badger.Txn) error {
 		e := badger.NewEntry(keyForRepo(tagsPrefix, repo), b)
 		return txn.SetEntry(e)
 	})
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%v", adler32.Checksum(b)), nil
 }
 
 func keyForRepo(prefix, repo string) []byte {

--- a/internal/database/badger_gc_test.go
+++ b/internal/database/badger_gc_test.go
@@ -42,8 +42,9 @@ func TestBadgerGarbageCollectorDoesStop(t *testing.T) {
 	time.Sleep(time.Second)
 
 	tags := []string{"latest", "v0.0.1", "v0.0.2"}
-	fatalIfError(t, db.SetTags(testRepo, tags))
-	_, err := db.Tags(testRepo)
+	_, err := db.SetTags(testRepo, tags)
+	fatalIfError(t, err)
+	_, err = db.Tags(testRepo)
 	fatalIfError(t, err)
 	t.Log("wrote tags successfully")
 


### PR DESCRIPTION
Closes #778 

There's already a field called `.spec.lastScanResult` with other information about the scan that is pretty close to `revision` (e.g. `tagCount`, `latestTags`), so I figured it would make more sense to put the revision inside it as well.