### PR TITLE
Add shortNames aliases for ImageRepository and ImagePolicy CRDs

### DIFF
--- a/api/v1beta2/imagepolicy_types.go
+++ b/api/v1beta2/imagepolicy_types.go
@@ -205,7 +205,7 @@ func (in *ImagePolicy) SetConditions(conditions []metav1.Condition) {
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=imgpol;imagepol;ip
+// +kubebuilder:resource:shortName=imgpol;imagepol
 // +kubebuilder:printcolumn:name="LatestImage",type=string,JSONPath=`.status.latestImage`
 
 // ImagePolicy is the Schema for the imagepolicies API

--- a/api/v1beta2/imagerepository_types.go
+++ b/api/v1beta2/imagerepository_types.go
@@ -197,7 +197,7 @@ func (in ImageRepository) GetRequeueAfter() time.Duration {
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=imgrepo;imagerepo;ir
+// +kubebuilder:resource:shortName=imgrepo;imagerepo
 // +kubebuilder:printcolumn:name="Last scan",type=string,JSONPath=`.status.lastScanResult.scanTime`
 // +kubebuilder:printcolumn:name="Tags",type=string,JSONPath=`.status.lastScanResult.tagCount`
 

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
@@ -14,7 +14,6 @@ spec:
     shortNames:
     - imgpol
     - imagepol
-    - ip
     singular: imagepolicy
   scope: Namespaced
   versions:

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -14,7 +14,6 @@ spec:
     shortNames:
     - imgrepo
     - imagerepo
-    - ir
     singular: imagerepository
   scope: Namespaced
   versions:


### PR DESCRIPTION
## Summary

This PR adds shortNames aliases for ImageRepository and ImagePolicy CRDs to enable shorter kubectl commands as requested in https://github.com/fluxcd/flux2/issues/5411 .

## Changes

- Add multiple aliases for ImageRepository: `imgrepo`, `imagerepo`
- Add multiple aliases for ImagePolicy: `imgpol`, `imagepol`

The aliases follow Flux ecosystem naming conventions using the `img` prefix, consistent with standard Docker/Kubernetes terminology and aligned with other Flux CRD shortNames (e.g., `gitrepo`, `helmrepo`, `hr`, `ks`). Additional aliases provide users with more flexibility in choosing their preferred shorthand.

## Verification

After applying the updated CRDs, the aliases are correctly registered:

```
$ kubectl api-resources | grep -E "imgpol|imgrepo"
imagepolicies                       imgpol,imagepol     image.toolkit.fluxcd.io/v1beta2          true         ImagePolicy
imagerepositories                   imgrepo,imagerepo   image.toolkit.fluxcd.io/v1beta2          true         ImageRepository
```

Users can now use shorter commands with multiple options:
- `kubectl get imgrepo` / `kubectl get imagerepo` instead of `kubectl get imagerepositories`
- `kubectl get imgpol` / `kubectl get imagepol` instead of `kubectl get imagepolicies`