### PR TITLE
Remove deprecated auto-login flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fluxcd/pkg/apis/acl v0.7.0
 	github.com/fluxcd/pkg/apis/event v0.17.0
 	github.com/fluxcd/pkg/apis/meta v1.12.0
-	github.com/fluxcd/pkg/auth v0.17.0
+	github.com/fluxcd/pkg/auth v0.18.0
 	github.com/fluxcd/pkg/cache v0.9.0
 	github.com/fluxcd/pkg/runtime v0.60.0
 	github.com/fluxcd/pkg/version v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/fluxcd/pkg/apis/event v0.17.0 h1:foEINE++pCJlWVhWjYDXfkVmGKu8mQ4BDBlb
 github.com/fluxcd/pkg/apis/event v0.17.0/go.mod h1:0fLhLFiHlRTDKPDXdRnv+tS7mCMIQ0fJxnEfmvGM/5A=
 github.com/fluxcd/pkg/apis/meta v1.12.0 h1:XW15TKZieC2b7MN8VS85stqZJOx+/b8jATQ/xTUhVYg=
 github.com/fluxcd/pkg/apis/meta v1.12.0/go.mod h1:+son1Va60x2eiDcTwd7lcctbI6C+K3gM7R+ULmEq1SI=
-github.com/fluxcd/pkg/auth v0.17.0 h1:jgum55f5K7Db6yI2bi4WeKojTzQS9KxlHCC0CsFs5x8=
-github.com/fluxcd/pkg/auth v0.17.0/go.mod h1:4h6s8VBNuec3tWd4xIReLw8BYPOKaIegjNMEbA4ikTU=
+github.com/fluxcd/pkg/auth v0.18.0 h1:71pGdKe0PVKWQvM3hEuyd3FD9dEUHtMuKMbUeiMl4aA=
+github.com/fluxcd/pkg/auth v0.18.0/go.mod h1:4h6s8VBNuec3tWd4xIReLw8BYPOKaIegjNMEbA4ikTU=
 github.com/fluxcd/pkg/cache v0.9.0 h1:EGKfOLMG3fOwWnH/4Axl5xd425mxoQbZzlZoLfd8PDk=
 github.com/fluxcd/pkg/cache v0.9.0/go.mod h1:jMwabjWfsC5lW8hE7NM3wtGNwSJ38Javx6EKbEi7INU=
 github.com/fluxcd/pkg/runtime v0.60.0 h1:d++EkV3FlycB+bzakB5NumwY4J8xts8i7lbvD6jBLeU=

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -111,8 +111,7 @@ type ImageRepositoryReconciler struct {
 		DatabaseWriter
 		DatabaseReader
 	}
-	DeprecatedLoginOpts []auth.Provider
-	AuthOptionsGetter   *registry.AuthOptionsGetter
+	AuthOptionsGetter *registry.AuthOptionsGetter
 
 	patchOptions []patch.Option
 }
@@ -270,7 +269,7 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 		Namespace: obj.GetNamespace(),
 		Operation: cache.OperationReconcile,
 	}
-	opts, err := r.AuthOptionsGetter.GetOptions(ctx, obj, involvedObject, r.DeprecatedLoginOpts...)
+	opts, err := r.AuthOptionsGetter.GetOptions(ctx, obj, involvedObject)
 	if err != nil {
 		e := fmt.Errorf("failed to configure authentication options: %w", err)
 		conditions.MarkFalse(obj, meta.ReadyCondition, imagev1.AuthenticationFailedReason, "%s", e)

--- a/internal/registry/options_test.go
+++ b/internal/registry/options_test.go
@@ -260,6 +260,14 @@ func TestNewAuthOptionsGetter_GetOptions(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "unsupported provider",
+			imageRepoSpec: imagev1.ImageRepositorySpec{
+				Image:    testImg,
+				Provider: "unsupported-provider",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -38,9 +37,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/fluxcd/pkg/auth"
-	"github.com/fluxcd/pkg/auth/aws"
-	"github.com/fluxcd/pkg/auth/azure"
-	"github.com/fluxcd/pkg/auth/gcp"
 	pkgcache "github.com/fluxcd/pkg/cache"
 	"github.com/fluxcd/pkg/runtime/acl"
 	"github.com/fluxcd/pkg/runtime/client"
@@ -96,9 +92,6 @@ func main() {
 		storageValueLogFileSize int64
 		gcInterval              uint16 // max value is 65535 minutes (~ 45 days) which is well under the maximum time.Duration
 		concurrent              int
-		awsAutoLogin            bool
-		gcpAutoLogin            bool
-		azureAutoLogin          bool
 		aclOptions              acl.Options
 		rateLimiterOptions      helper.RateLimiterOptions
 		featureGates            feathelper.FeatureGates
@@ -113,11 +106,6 @@ func main() {
 	flag.Uint16Var(&gcInterval, "gc-interval", 10, "The number of minutes to wait between garbage collections. 0 disables the garbage collector.")
 	flag.IntVar(&concurrent, "concurrent", 4, "The number of concurrent resource reconciles.")
 
-	// NOTE: Deprecated flags.
-	flag.BoolVar(&awsAutoLogin, "aws-autologin-for-ecr", false, "(AWS) Attempt to get credentials for images in Elastic Container Registry, when no secret is referenced")
-	flag.BoolVar(&gcpAutoLogin, "gcp-autologin-for-gcr", false, "(GCP) Attempt to get credentials for images in Google Container Registry, when no secret is referenced")
-	flag.BoolVar(&azureAutoLogin, "azure-autologin-for-acr", false, "(Azure) Attempt to get credentials for images in Azure Container Registry, when no secret is referenced")
-
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
 	leaderElectionOptions.BindFlags(flag.CommandLine)
@@ -130,12 +118,6 @@ func main() {
 	flag.Parse()
 
 	logger.SetLogger(logger.NewLogger(logOptions))
-
-	if awsAutoLogin || gcpAutoLogin || azureAutoLogin {
-		setupLog.Error(errors.New("use of deprecated flags"),
-			"autologin flags have been deprecated. These flags will be removed in a future release."+
-				" Please update the respective ImageRepository objects with .spec.provider field.")
-	}
 
 	if err := featureGates.WithLogger(setupLog).SupportedFeatures(features.FeatureGates()); err != nil {
 		setupLog.Error(err, "unable to load feature gates")
@@ -265,31 +247,19 @@ func main() {
 		}
 	}
 
-	var deprecatedLoginOpts []auth.Provider
-	if awsAutoLogin {
-		deprecatedLoginOpts = append(deprecatedLoginOpts, aws.Provider{})
-	}
-	if azureAutoLogin {
-		deprecatedLoginOpts = append(deprecatedLoginOpts, azure.Provider{})
-	}
-	if gcpAutoLogin {
-		deprecatedLoginOpts = append(deprecatedLoginOpts, gcp.Provider{})
-	}
-
 	authOptionsGetter := &registry.AuthOptionsGetter{
 		Client:     mgr.GetClient(),
 		TokenCache: tokenCache,
 	}
 
 	if err := (&controller.ImageRepositoryReconciler{
-		Client:              mgr.GetClient(),
-		EventRecorder:       eventRecorder,
-		Metrics:             metricsH,
-		Database:            db,
-		ControllerName:      controllerName,
-		TokenCache:          tokenCache,
-		AuthOptionsGetter:   authOptionsGetter,
-		DeprecatedLoginOpts: deprecatedLoginOpts,
+		Client:            mgr.GetClient(),
+		EventRecorder:     eventRecorder,
+		Metrics:           metricsH,
+		Database:          db,
+		ControllerName:    controllerName,
+		TokenCache:        tokenCache,
+		AuthOptionsGetter: authOptionsGetter,
 	}).SetupWithManager(mgr, controller.ImageRepositoryReconcilerOptions{
 		RateLimiter: helper.GetRateLimiter(rateLimiterOptions),
 	}); err != nil {


### PR DESCRIPTION
## Summary

Remove support for deprecated auto-login controller flags as part of preparing image automation APIs for GA.

This addresses task 3 "Remove deprecated code paths (e.g. auto-login flags in IRC)" from https://github.com/fluxcd/flux2/issues/5411.

Removes the following flags that have been deprecated since v0.25.0:
- `--aws-autologin-for-ecr`
- `--gcp-autologin-for-gcr` 
- `--azure-autologin-for-acr`

## Changes

- Remove flag definitions and variables from main.go
- Remove `DeprecatedLoginOpts` field from `ImageRepositoryReconciler`
- Remove deprecated login options handling from registry options
- Clean up unused imports (`errors`, `aws`, `azure`, `gcp` packages)
- Clarify switch statement logic for provider auto-login

## Breaking Change

This is a **planned breaking change** for flags that have been deprecated since v0.25.0 (February 2023). In v0.26.0, it was announced that these flags would be removed "at least one minor version after this release" - sufficient time has now passed (v0.35.x).

The flags currently show error messages when used, and users have been advised to migrate to the `.spec.provider` field.

After this change, using these flags will cause the controller to fail with "flag provided but not defined" error.

## Migration

Users must update their ImageRepository objects to use the `.spec.provider` field instead:

```yaml
apiVersion: image.toolkit.fluxcd.io/v1beta2
kind: ImageRepository
metadata:
  name: my-app
spec:
  image: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-app
  provider: aws  # Use this instead of --aws-autologin-for-ecr flag
```

Related to https://github.com/fluxcd/flux2/issues/5411 (task 3)