### PR TITLE
Fix failing test case in options test

### DIFF
--- a/internal/registry/options_test.go
+++ b/internal/registry/options_test.go
@@ -150,7 +150,7 @@ func TestNewAuthOptionsGetter_GetOptions(t *testing.T) {
 				Image:    "123456789000.dkr.ecr.us-east-2.amazonaws.com/test",
 				Provider: "aws",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "cloud provider repo without login",


### PR DESCRIPTION
`make test` was failing in the main branch - there is no error here with a valid provider during the test run. 

@matheuscscp I am working on `flux reconcile image policy` and wanted the tests to work out of the box 😄 
Let me know if I should fix it a different way. 