### PR TITLE
Fix controllers not watching reconcile requests from annotations

### DIFF
--- a/internal/controller/imagepolicy_controller.go
+++ b/internal/controller/imagepolicy_controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/fluxcd/pkg/runtime/conditions"
 	helper "github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/patch"
+	"github.com/fluxcd/pkg/runtime/predicates"
 	pkgreconcile "github.com/fluxcd/pkg/runtime/reconcile"
 
 	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1"
@@ -139,7 +140,9 @@ func (r *ImagePolicyReconciler) SetupWithManager(mgr ctrl.Manager, opts ImagePol
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&imagev1.ImagePolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&imagev1.ImagePolicy{}, builder.WithPredicates(
+			predicate.Or(predicate.GenerationChangedPredicate{}, predicates.ReconcileRequestedPredicate{}),
+		)).
 		Watches(
 			&imagev1.ImageRepository{},
 			handler.EnqueueRequestsFromMapFunc(r.imagePoliciesForRepository),

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -35,6 +35,7 @@ import (
 	kuberecorder "k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -125,8 +126,9 @@ func (r *ImageRepositoryReconciler) SetupWithManager(mgr ctrl.Manager, opts Imag
 	r.patchOptions = getPatchOptions(imageRepositoryOwnedConditions, r.ControllerName)
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&imagev1.ImageRepository{}).
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicates.ReconcileRequestedPredicate{})).
+		For(&imagev1.ImageRepository{}, builder.WithPredicates(
+			predicate.Or(predicate.GenerationChangedPredicate{}, predicates.ReconcileRequestedPredicate{}),
+		)).
 		WithOptions(controller.Options{
 			RateLimiter: opts.RateLimiter,
 		}).


### PR DESCRIPTION
While working on https://github.com/fluxcd/flux2/pull/5492 we noticed that the ImagePolicy controller was lacking the predicate for watching reconcile requests from the annotation. This bug escaped due to a weakness on the controller test for this scenario where the object was being created with the annotation, so the first reconciliation was copying the annotation to the status field. After changing this test to create the object without the annotation and to add it later, the test started to fail, making the bug surface.

We are also improving the same test for the ImageRepository controller, and modifying its predicate setup to match the style of the majority of the other controllers.