### PR TITLE
refactor: make alphabetical sort implementation more intuitive

### DIFF
--- a/internal/policy/alphabetical.go
+++ b/internal/policy/alphabetical.go
@@ -57,10 +57,11 @@ func (p *Alphabetical) Latest(versions []string) (string, error) {
 	}
 
 	var sorted sort.StringSlice = versions
-	if p.Order == AlphabeticalOrderDesc {
+	if p.Order == AlphabeticalOrderAsc {
+		// Default StringSlice.Sort is ascending
 		sort.Sort(sorted)
 	} else {
 		sort.Sort(sort.Reverse(sorted))
 	}
-	return sorted[0], nil
+	return sorted[len(sorted)-1], nil
 }


### PR DESCRIPTION
When looking into the implementation to understand behavior, it's very confusing to invert the ordering in relation to how the mental model works. This aligns implementation and mental model of the sort of versions in the end.

The part that was most confusing in my experience is that the docs vaguely mention "latest" and "last" element, but when looking at the implenetation, it seems we take the first element of the array - this is very unintuitive, and only makes sense after understanding that the implementation internally sorts exactly the other way around. This change should have no real impact on performance, but should make the code much more readable in my opinion. Tests are unchanged, because behavior is unchanged.