### PR TITLE
Restore GitHub PAT for backports

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write # for creating pull requests against release branches.
     uses: fluxcd/gha-workflows/.github/workflows/backport.yaml@v0.4.0
     secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Backports need broader permissions:

* GitHub won't trigger GHA workflows in PRs opened by an ephemeral PAT from another GHA workflow
* GitHub won't accept pushes to GHA workflow files by an ephemeral PAT from another GHA workflow