### PR TITLE
Retry policy resolution when no tags found in database

### DIFF
--- a/internal/controller/imagepolicy_controller_test.go
+++ b/internal/controller/imagepolicy_controller_test.go
@@ -98,7 +98,9 @@ func TestImagePolicyReconciler_imageRepoHasNoTags(t *testing.T) {
 		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(imagePolicy), imagePolicy)
 		return err == nil && !conditions.IsReady(imagePolicy) &&
 			conditions.GetReason(imagePolicy, meta.ReadyCondition) == imagev1.DependencyNotReadyReason
-	}).Should(BeTrue())
+	}, 6*time.Second).Should(BeTrue())
+
+	g.Expect(conditions.GetMessage(imagePolicy, meta.ReadyCondition)).To(BeEquivalentTo("retrying in 30s error: no tags in database"))
 }
 
 func TestImagePolicyReconciler_ignoresImageRepoNotReadyEvent(t *testing.T) {
@@ -527,10 +529,9 @@ func TestImagePolicyReconciler_objectLevelWorkloadIdentityFeatureGate(t *testing
 
 		g.Eventually(func() bool {
 			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(imagePolicy), imagePolicy)
-			logPolicyStatus(t, imagePolicy)
 			return err == nil && !conditions.IsReady(imagePolicy) &&
 				conditions.GetReason(imagePolicy, meta.ReadyCondition) == imagev1.DependencyNotReadyReason
-		}).Should(BeTrue())
+		}, 6*time.Second).Should(BeTrue())
 	})
 }
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -49,7 +49,7 @@ import (
 
 // for Eventually
 const (
-	timeout                = time.Second * 30
+	timeout                = time.Second * 25
 	contextTimeout         = time.Second * 20
 	interval               = time.Second * 1
 	reconciliationInterval = time.Second * 2
@@ -101,10 +101,11 @@ func TestMain(m *testing.M) {
 	}
 
 	if err = (&ImagePolicyReconciler{
-		Client:            testEnv,
-		Database:          database.NewBadgerDatabase(testBadgerDB),
-		EventRecorder:     record.NewFakeRecorder(256),
-		AuthOptionsGetter: optGetter,
+		Client:                    testEnv,
+		Database:                  database.NewBadgerDatabase(testBadgerDB),
+		EventRecorder:             record.NewFakeRecorder(256),
+		AuthOptionsGetter:         optGetter,
+		DependencyRequeueInterval: 30 * time.Second,
 	}).SetupWithManager(testEnv, ImagePolicyReconcilerOptions{
 		RateLimiter: controller.GetDefaultRateLimiter(),
 	}); err != nil {


### PR DESCRIPTION
Changes:
- Add retry with backoff for listing tags to cope with race conditions at startup
- Add standard controller flag `--requeue-dependency` (default 30s)
- Requeue policies according to the flag when no tags are found in the database

Fix: #844

## Release candidate

Images containing this fix:

- `ghcr.io/fluxcd/image-reflector-controller:rc-0c2d58b3`
- `docker.io/fluxcd/image-reflector-controller:rc-0c2d58b3`

[Bootstrap](https://fluxcd.io/flux/installation/configuration/bootstrap-customization) patch:

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - gotk-components.yaml
  - gotk-sync.yaml
patches:
  - target:
      kind: Deployment
      name: image-reflector-controller
    patch: |
      - op: replace
        path: /spec/template/spec/containers/0/image
        value: ghcr.io/fluxcd/image-reflector-controller:rc-0c2d58b3
```

[FluxInstance](https://github.com/controlplaneio-fluxcd/flux-operator) patch:

```yaml
apiVersion: fluxcd.controlplane.io/v1
kind: FluxInstance
metadata:
  name: flux
  namespace: flux-system
spec:
  distribution:
    version: "2.7.x"
    registry: "ghcr.io/fluxcd"
  kustomize:
    patches:
      - target:
          kind: Deployment
          name: image-reflector-controller
        patch: |
          - op: replace
            path: /spec/template/spec/containers/0/image
            value: ghcr.io/fluxcd/image-reflector-controller:rc-0c2d58b3
```
