### PR TITLE
fix: clear Result when Reconcile returns an error

### DIFF
--- a/internal/controller/imagepolicy_controller.go
+++ b/internal/controller/imagepolicy_controller.go
@@ -280,6 +280,12 @@ func (r *ImagePolicyReconciler) reconcile(ctx context.Context, sp *patch.SerialP
 	defer func() {
 		rs := pkgreconcile.NewResultFinalizer(isSuccess, readyMsg)
 		retErr = rs.Finalize(obj, result, retErr)
+		// controller-runtime logs a warning and ignores Result when Reconcile
+		// returns both a non-zero Result and a non-nil error. Clear the Result
+		// whenever there is an error so the log stays clean.
+		if retErr != nil {
+			result = ctrl.Result{}
+		}
 
 		// Presence of reconciling means that the reconciliation didn't succeed.
 		// Set the Reconciling reason to ProgressingWithRetry to indicate a

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -219,6 +219,12 @@ func (r *ImageRepositoryReconciler) reconcile(ctx context.Context, sp *patch.Ser
 		readyMsg := fmt.Sprintf("successful scan: found %d tags with checksum %s", numFoundTags, tagsChecksum)
 		rs := reconcile.NewResultFinalizer(isSuccess, readyMsg)
 		retErr = rs.Finalize(obj, result, retErr)
+		// controller-runtime logs a warning and ignores Result when Reconcile
+		// returns both a non-zero Result and a non-nil error. Clear the Result
+		// whenever there is an error so the log stays clean.
+		if retErr != nil {
+			result = ctrl.Result{}
+		}
 
 		// Presence of reconciling means that the reconciliation didn't succeed.
 		// Set the Reconciling reason to ProgressingWithRetry to indicate a


### PR DESCRIPTION
## Summary

Both `ImageRepositoryReconciler.Reconcile` and `ImagePolicyReconciler.Reconcile` wrap the sub-reconciler with a named-return form that always emits both values:

```go
result, retErr = r.reconcile(ctx, ...)
return
```

controller-runtime emits the warning referenced in #661 when a `Reconcile` call returns both a non-zero `Result` and a non-nil error — the `Result` is ignored in that case and the object is re-queued with the error's exponential backoff. Populating a `RequeueAfter` and then returning an error gives the misleading impression that the caller's requested interval applies.

Drop the `Result` when there is an error so controller-runtime sees `(ctrl.Result{}, retErr)` and the warning no longer fires. Behaviour after the change is what controller-runtime was doing anyway (the `Result` was being discarded); this just avoids the log noise.

Fixes #661

Signed-off-by: Ali <alliasgher123@gmail.com>