### PR TITLE
docs: add debugging tips to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,3 +53,43 @@ If you made any changes to CRDs API, you can update CRDs API reference doc by
 ```bash
 make api-docs
 ```
+
+## Debugging the controller locally
+
+When reproducing an issue or stepping through reconciliation logic, the
+following knobs make local runs cheaper and the resulting logs easier to
+read.
+
+### Limit the watched namespace
+
+The controller watches every namespace by default. To narrow it to a single
+namespace, set the `RUNTIME_NAMESPACE` environment variable before invoking
+`make run`:
+
+```sh
+RUNTIME_NAMESPACE=flux-system make run
+```
+
+### Reduce reconcile concurrency
+
+Each `ImageRepository` and `ImagePolicy` reconcile is processed concurrently
+(default `--concurrent=4`). When debugging it is almost always easier to
+follow a serial trace; pass `--concurrent=1` so reconciles run one at a
+time:
+
+```sh
+go run ./main.go --concurrent=1
+```
+
+### Suspend unrelated objects
+
+If the controller is sharing a cluster with other Flux objects, suspend
+anything not relevant to the test you're running so their reconciles don't
+interleave with yours:
+
+```sh
+flux suspend image repository <name>
+flux suspend image policy <name>
+```
+
+Resume with `flux resume image repository|policy <name>` when you're done.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,7 +78,7 @@ follow a serial trace; pass `--concurrent=1` so reconciles run one at a
 time:
 
 ```sh
-go run ./main.go --concurrent=1
+go run ./main.go --storage-path=./data --concurrent=1
 ```
 
 ### Suspend unrelated objects


### PR DESCRIPTION
## Summary
Adds a 'Debugging the controller locally' section to `DEVELOPMENT.md` covering knobs not already in 'How to run the controller locally':

- `RUNTIME_NAMESPACE` to scope the watch
- `--concurrent=1` to serialize reconciles for a clean trace
- `flux suspend` for unrelated objects sharing the cluster

Cross-controller setup is already documented (or n/a for this controller) and is not duplicated here.

Assisted-by: Claude/claude-opus-4-7