### PR TITLE
Add categories to image-reflector CRDs

### DIFF
--- a/api/v1/imagepolicy_types.go
+++ b/api/v1/imagepolicy_types.go
@@ -197,7 +197,7 @@ func (in *ImagePolicy) SetConditions(conditions []metav1.Condition) {
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=imgpol;imagepol
+// +kubebuilder:resource:shortName=imgpol;imagepol,categories=all;fluxcd;fluxcd-images
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.status.latestRef.name`
 // +kubebuilder:printcolumn:name="Tag",type=string,JSONPath=`.status.latestRef.tag`
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/api/v1/imagerepository_types.go
+++ b/api/v1/imagerepository_types.go
@@ -210,7 +210,7 @@ func (in ImageRepository) GetRequeueAfter() time.Duration {
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=imgrepo;imagerepo
+// +kubebuilder:resource:shortName=imgrepo;imagerepo,categories=all;fluxcd;fluxcd-images
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.image"
 // +kubebuilder:printcolumn:name="Tags",type=string,JSONPath=`.status.lastScanResult.tagCount`
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/api/v1beta2/imagepolicy_types.go
+++ b/api/v1beta2/imagepolicy_types.go
@@ -198,7 +198,6 @@ func (in *ImagePolicy) SetConditions(conditions []metav1.Condition) {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=imgpol;imagepol
 // +kubebuilder:skipversion
 
 // ImagePolicy is the Schema for the imagepolicies API

--- a/api/v1beta2/imagerepository_types.go
+++ b/api/v1beta2/imagerepository_types.go
@@ -212,7 +212,6 @@ func (in ImageRepository) GetRequeueAfter() time.Duration {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=imgrepo;imagerepo
 // +kubebuilder:skipversion
 
 // ImageRepository is the Schema for the imagerepositories API

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: image.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-images
     kind: ImagePolicy
     listKind: ImagePolicyList
     plural: imagepolicies

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: image.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-images
     kind: ImageRepository
     listKind: ImageRepositoryList
     plural: imagerepositories


### PR DESCRIPTION
This adds the standard Flux resource categories to every CRD in this
repository so users can list Flux resources with kubectl, for example:

```
kubectl get fluxcd          # all Flux resources
kubectl get fluxcd-images   # all resources in this category
kubectl get all             # now includes Flux resources
```

Each CRD gets exactly three categories:

```
all
fluxcd
fluxcd-images
```

The `+kubebuilder:resource` markers were removed from the skipped older
API versions, since they interfere with CRD generation, and the CRDs
were regenerated with `make manifests`.

Part of fluxcd/flux2#5947
