### PR TITLE
Fix ObservedExclusionList doc-comment field reference

### DIFF
--- a/api/v1/imagerepository_types.go
+++ b/api/v1/imagerepository_types.go
@@ -155,7 +155,7 @@ type ImageRepositoryStatus struct {
 
 	// ObservedExclusionList is a list of observed exclusion list. It reflects
 	// the exclusion rules used for the observed scan result in
-	// spec.lastScanResult.
+	// status.lastScanResult.
 	ObservedExclusionList []string `json:"observedExclusionList,omitempty"`
 
 	meta.ReconcileRequestStatus `json:",inline"`

--- a/api/v1beta2/imagerepository_types.go
+++ b/api/v1beta2/imagerepository_types.go
@@ -159,7 +159,7 @@ type ImageRepositoryStatus struct {
 
 	// ObservedExclusionList is a list of observed exclusion list. It reflects
 	// the exclusion rules used for the observed scan result in
-	// spec.lastScanResult.
+	// status.lastScanResult.
 	ObservedExclusionList []string `json:"observedExclusionList,omitempty"`
 
 	meta.ReconcileRequestStatus `json:",inline"`

--- a/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
@@ -301,7 +301,7 @@ spec:
                 description: |-
                   ObservedExclusionList is a list of observed exclusion list. It reflects
                   the exclusion rules used for the observed scan result in
-                  spec.lastScanResult.
+                  status.lastScanResult.
                 items:
                   type: string
                 type: array

--- a/docs/api/v1/image-reflector.md
+++ b/docs/api/v1/image-reflector.md
@@ -1041,7 +1041,7 @@ ScanResult
 <td>
 <p>ObservedExclusionList is a list of observed exclusion list. It reflects
 the exclusion rules used for the observed scan result in
-spec.lastScanResult.</p>
+status.lastScanResult.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary

Part of fluxcd/flux2#5941 (item 2) — the `ObservedExclusionList` field's doc-comment referenced `spec.lastScanResult`, but `LastScanResult` is a `status` field (`status.lastScanResult`), not part of the spec. Fixed in both `api/v1` and `api/v1beta2`, and regenerated the CRD via `make manifests`.

Cosmetic/documentation only — no functional or behavioral change.

## Test plan

- `go build ./...` and `cd api && go build ./...` — clean.
- `gofmt -l` on changed files — no output (already formatted).
- `go vet` in the `api` submodule — clean.
- `make manifests` regenerated `config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml`; diff confirmed to be exactly the one corrected description string, nothing else changed.