### PR TITLE
docs: expand local debugging guidance in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,6 +46,121 @@ You can run the controller on your host by
 make run
 ```
 
+`make run` starts the binary against the cluster in your current kubeconfig
+and sets `--storage-path=./data` so tag metadata is written under the local
+checkout instead of the in-cluster default (`/data`). With the default flags
+the process also listens for:
+
+| Endpoint | Default address | Purpose |
+| --- | --- | --- |
+| Health probes | `:9440` (`--health-addr`) | Liveness / readiness |
+| Metrics / pprof | `:8080` (`--metrics-addr`) | Prometheus metrics and pprof handlers |
+
+## Debugging the controller locally
+
+Use this section when you need to reproduce a reported issue or step through
+`ImageRepository` / `ImagePolicy` reconciliation against a real cluster.
+
+### Avoid racing an in-cluster controller
+
+If the cluster already runs `image-reflector-controller`, scale it down before
+starting your local process so only one instance reconciles objects and writes
+to storage:
+
+```sh
+kubectl -n flux-system scale deploy/image-reflector-controller --replicas=0
+```
+
+Restore it when you are done:
+
+```sh
+kubectl -n flux-system scale deploy/image-reflector-controller --replicas=1
+```
+
+### Suspend objects that are not part of the reproduction
+
+Shared clusters often have many `ImageRepository` and `ImagePolicy` objects.
+Suspend everything you do not need so their reconciles (and registry traffic)
+do not interleave with the case you are debugging:
+
+```sh
+flux suspend image-repository --all
+flux suspend image-policy --all
+```
+
+`--all` applies to the current kubeconfig namespace (commonly `flux-system`).
+Resume specific objects (or use `flux resume <kind> --all`) when finished.
+
+### Increase log verbosity
+
+`make run` uses the default `info` level. For a console-friendly local trace,
+keep the same storage path as `make run` and raise verbosity:
+
+```sh
+go run ./main.go --storage-path=./data --log-level=debug --log-encoding=console
+```
+
+Supported `--log-level` values are `trace`, `debug`, `info`, and `error`.
+
+### Exercise a minimal ImageRepository / ImagePolicy pair
+
+Create (or leave unsuspended) only the objects under test, then watch the local
+process logs while they reconcile. Useful checks:
+
+```sh
+kubectl get imagerepository <name> -o yaml
+kubectl get imagepolicy <name> -o yaml
+```
+
+Confirm the `ImageRepository` status lists recent tags and the `ImagePolicy`
+status shows the elected image (and digest, when reflection is enabled). Tag
+metadata for the local process is stored under `./data` (see `--storage-path`
+above).
+
+### Cross-controller interactions
+
+`image-reflector-controller` scans registries and elects tags; it does not
+write to Git. Downstream, [`image-automation-controller`](https://github.com/fluxcd/image-automation-controller)
+consumes `ImagePolicy` status and patches image refs in Git.
+
+When debugging against a shared cluster, keep watching all namespaces (the
+default `--watch-all-namespaces=true`). Narrowing the cache with
+`--watch-all-namespaces=false` / `RUNTIME_NAMESPACE` hides cross-namespace
+`ImagePolicy` → `ImageRepository` refs that often matter in reproductions, so
+it is a poor default for local debugging. Prefer suspending unrelated objects
+instead.
+
+If you need to see how automation reacts to a new elected tag, run or observe
+`image-automation-controller` separately after the local reflector has updated
+the `ImagePolicy` status.
+
+### Debugging with VS Code
+
+Create a `.vscode/launch.json` file:
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch image-reflector-controller",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "args": [
+                "--storage-path=./data",
+                "--log-level=debug",
+                "--log-encoding=console"
+            ]
+        }
+    ]
+}
+```
+
+Scale down the in-cluster Deployment first, then start debugging with
+**Run → Start Debugging**.
+
 ## How to generate and update CRDs API reference documentation
 
 If you made any changes to CRDs API, you can update CRDs API reference doc by


### PR DESCRIPTION
## Summary
- Expand `DEVELOPMENT.md` with a practical local-debugging guide: scale down the in-cluster Deployment, suspend unrelated ImageRepository/ImagePolicy objects, raise log verbosity (keeping `--storage-path=./data`), exercise a minimal object pair, document cross-controller interaction with image-automation-controller, and attach VS Code.
- Document the local listen addresses used by `make run`.
- Explicitly avoid the incorrect `RUNTIME_NAMESPACE` / `--concurrent=1` advice from closed #881; explain why keeping `--watch-all-namespaces` (default) is preferred when reproducing cross-namespace behaviour.

Fixes #245

## Test plan
- [ ] Read the new section for accuracy against `main.go` flags and `make run`
- [ ] Confirm `flux suspend image-repository|image-policy --all` command names
- [ ] DCO Signed-off-by present on the commit